### PR TITLE
Add MinIO backend configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,8 +18,8 @@ curl -L -o docker-compose.yml https://raw.githubusercontent.com/dvejsada/mcp-ms-
   - Copy `.env.example` to `.env`
   - Edit `.env`:
     - `LOG_LEVEL=INFO|DEBUG`
-    - `UPLOAD_STRATEGY=LOCAL|S3|GCS|AZURE`
-    - For S3/GCS/AZURE, fill the required credentials
+    - `UPLOAD_STRATEGY=LOCAL|S3|GCS|AZURE|MINIO`
+    - For S3/GCS/AZURE/MINIO, fill the required credentials
 - Start the server:
 ```bash
 docker-compose up -d
@@ -54,7 +54,24 @@ Dynamic email tools (optional):
 
 Outputs:
 - LOCAL: files saved to `output/` and reported back
-- S3/GCS/AZURE: a time-limited download link is returned (TTL via `SIGNED_URL_EXPIRES_IN`)
+- S3/GCS/AZURE/MINIO: a time-limited download link is returned (TTL via `SIGNED_URL_EXPIRES_IN`)
+
+### MinIO private storage
+
+You can point the server to a self-hosted MinIO instance (or any other S3 compatible storage) by setting `UPLOAD_STRATEGY=MINIO` and providing:
+
+```
+MINIO_ENDPOINT=https://minio.example.com
+MINIO_ACCESS_KEY=...
+MINIO_SECRET_KEY=...
+MINIO_BUCKET=office-documents
+MINIO_REGION=us-east-1          # optional, defaults to us-east-1
+MINIO_VERIFY_SSL=true           # optional, set to false for self-signed endpoints
+MINIO_PATH_STYLE=true           # optional, defaults to true (recommended for MinIO)
+SIGNED_URL_EXPIRES_IN=3600      # optional TTL in seconds for download links
+```
+
+The MinIO backend reuses the existing boto3 dependency and generates pre-signed download links just like the AWS S3 strategy. Ensure the bucket exists and the provided credentials have `s3:PutObject`/`s3:GetObject` permissions.
 
 ## 3) Custom templates
 

--- a/upload_tools/backends/__init__.py
+++ b/upload_tools/backends/__init__.py
@@ -1,0 +1,13 @@
+from .local import upload_to_local_folder
+from .s3 import upload_to_s3
+from .gcs import upload_to_gcs
+from .azure import upload_to_azure
+from .minio import upload_to_minio
+
+__all__ = [
+    "upload_to_local_folder",
+    "upload_to_s3",
+    "upload_to_gcs",
+    "upload_to_azure",
+    "upload_to_minio",
+]

--- a/upload_tools/backends/minio.py
+++ b/upload_tools/backends/minio.py
@@ -1,0 +1,59 @@
+import logging
+
+from ..utils import get_content_type
+
+logger = logging.getLogger(__name__)
+
+
+def upload_to_minio(file_object, file_name: str, minicfg, signed_url_expires_in: int):
+    """Upload a file to a private MinIO bucket and generate a presigned URL."""
+
+    if not minicfg:
+        logger.error("MinIO configuration not provided")
+        return None
+
+    try:
+        import boto3  # type: ignore
+        from botocore.config import Config as BotoConfig  # type: ignore
+        from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError  # type: ignore
+    except ImportError:
+        logger.error("boto3/botocore are required for MinIO uploads")
+        return None
+
+    content_type = get_content_type(file_name)
+
+    try:
+        addressing_style = "path" if minicfg.path_style else "auto"
+        endpoint_is_https = minicfg.endpoint.lower().startswith("https")
+        boto_cfg = BotoConfig(signature_version="s3v4", s3={"addressing_style": addressing_style})
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id=minicfg.access_key,
+            aws_secret_access_key=minicfg.secret_key,
+            region_name=minicfg.region,
+            endpoint_url=minicfg.endpoint,
+            use_ssl=endpoint_is_https,
+            verify=minicfg.verify_ssl if endpoint_is_https else False,
+            config=boto_cfg,
+        )
+
+        file_object.seek(0)
+        extra_args = {"ContentType": content_type}
+        s3_client.upload_fileobj(file_object, minicfg.bucket, file_name, ExtraArgs=extra_args)
+
+        url = s3_client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": minicfg.bucket, "Key": file_name},
+            ExpiresIn=signed_url_expires_in,
+        )
+
+        return (
+            "Link to created document to be shared with user in markdown format: "
+            f"{url} . Link is valid for {signed_url_expires_in} seconds."
+        )
+    except (BotoCoreError, ClientError, NoCredentialsError) as err:
+        logger.error("MinIO upload error: %s", err)
+        return None
+    except Exception as exc:
+        logger.error("Unexpected MinIO upload error: %s", exc)
+        return None

--- a/upload_tools/main.py
+++ b/upload_tools/main.py
@@ -5,6 +5,7 @@ from .backends.local import upload_to_local_folder
 from .backends.s3 import upload_to_s3
 from .backends.gcs import upload_to_gcs
 from .backends.azure import upload_to_azure
+from .backends.minio import upload_to_minio
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,8 @@ elif UPLOAD_STRATEGY == "GCS":
     logger.info("GCS upload strategy set.")
 elif UPLOAD_STRATEGY == "AZURE":
     logger.info("Azure Blob upload strategy set.")
+elif UPLOAD_STRATEGY == "MINIO":
+    logger.info("MinIO upload strategy set.")
 
 
 def upload_file(file_object, suffix: str):
@@ -44,5 +47,7 @@ def upload_file(file_object, suffix: str):
         return upload_to_gcs(file_object, object_name, cfg.storage.gcs, SIGNED_URL_EXPIRES_IN)
     elif UPLOAD_STRATEGY == "AZURE":
         return upload_to_azure(file_object, object_name, cfg.storage.azure, SIGNED_URL_EXPIRES_IN)
+    elif UPLOAD_STRATEGY == "MINIO":
+        return upload_to_minio(file_object, object_name, cfg.storage.minio, SIGNED_URL_EXPIRES_IN)
     else:
         return "No upload strategy set, presentation cannot be created."


### PR DESCRIPTION
**1. Configuration**  
_New MINIO strategy in `config.py`:_
- Added `MinioSettings` class (endpoint, credentials, bucket, SSL/path-style options).
- Extended `StorageStrategy` (including MINIO) and `StorageSettings` to require MinIO configuration when selected.
- Read `MINIO_*` environment variables in `Config.from_env()` with sensible defaults where appropriate.

**2. Upload backend**  
_Dedicated MinIO backend in `upload_tools/backends/minio.py`:_
- Reuses `boto3` in S3-compatible mode.
- Supports path-style addressing, custom endpoint and optional SSL verification.
- Generates presigned URLs analogous to AWS.

_Strategy routing in `upload_tools/main.py`:_
- Import and branch for MINIO with log message: `"MinIO upload strategy set."`.
- `upload_file` now calls `upload_to_minio` when the strategy is MINIO.
- Updated backend exports in `upload_tools/backends/__init__.py`.

**3. Documentation**  
_README:_
- Updated instructions for `UPLOAD_STRATEGY=LOCAL|S3|GCS|AZURE|MINIO`.
- Added dedicated “MinIO private storage” section with environment variables, options and presigned link behavior.

_`.env.example`:_
- Added MinIO S3 configuration variables.
- Described the new strategy and MinIO parameters (endpoint, access/secret key, bucket, region, `verify_ssl`, `path_style`).
- Noted that `SIGNED_URL_EXPIRES_IN` also applies to MINIO.