### PR TITLE
fix(helpers): remove automatic percentage formatting for <1

### DIFF
--- a/xlsx_tools/helpers.py
+++ b/xlsx_tools/helpers.py
@@ -359,8 +359,6 @@ def add_table_to_sheet(
                 if row_idx == 0:
                     cell.font = header_font
                     cell.fill = header_fill
-                elif isinstance(cell.value, float) and 0 < cell.value <= 1:
-                    cell.number_format = '0.00%'
                 elif isinstance(cell.value, (int, float)) and cell.value >= 1000:
                     cell.number_format = '#,##0'
             except Exception as e:


### PR DESCRIPTION
# Summary

This pull request makes a minor adjustment to the formatting logic in the `add_table_to_sheet` function within `xlsx_tools/helpers.py`. Specifically, it removes the automatic formatting of float values between 0 and 1 as percentages.

- Formatting logic update:
  * Removed the condition that formatted float values between 0 and 1 as percentages in the `add_table_to_sheet` function, so these values will no longer be automatically displayed as percentages in the generated Excel sheet.
  
 # Bug Example
 
 I've requested an xlsx with LLM pricing and the LLM requested as follows
 
 ```json 
 {
  "markdown_content": "\n## Sheet: Custos LLMs\n| LLM | Input Price (per M tokens) | Output Price (per M tokens) | Input Tokens (M) | Output Tokens (M) | Total Cost (€) |\n|---|---|---|---|---|---|\n| Gemini 2.5 Flash | 0.075 | 0.30 | 10 | 2 | =D[0]*B[0]+E[0]*C[0] |\n| Gemini 2.5 Pro | 1.25 | 5.00 | 10 | 2 | =D[1]*B[1]+E[1]*C[1] |\n| OpenAI GPT 4.1 Nano | 2.00 | 8.00 | 10 | 2 | =D[2]*B[2]+E[2]*C[2] |\n| OpenAI GPT5 | 2.50 | 10.00 | 10 | 2 | =D[3]*B[3]+E[3]*C[3] |\n"
}
```

The output was 

<img width="367" height="70" alt="image" src="https://github.com/user-attachments/assets/731c9d77-5782-4c1f-bba1-8842fae7aa0d" />

And as you can see the input was 0.075 and 0.30.

After some digging we've noticed that an automatic assumption of all numbers between 0 and 1 are percentage, and I think that's not valid.
In case it's def a bug here is a fix, let me know otherwise :)