### PR TITLE
feat(upload): add optional filename parameter for file uploads

### DIFF
--- a/docx_tools/base_docx_tool.py
+++ b/docx_tools/base_docx_tool.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def markdown_to_word(markdown_content, title=None, author=None, subject=None,
-                     header_text=None, footer_text=None, include_toc=False):
+                     header_text=None, footer_text=None, include_toc=False, file_name=None):
     """Convert Markdown to Word document."""
     logger.info("Starting markdown_to_word conversion")
     path = load_templates()
@@ -211,7 +211,7 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
         doc.save(file_object)
         file_object.seek(0)
 
-        result = upload_file(file_object, "docx")
+        result = upload_file(file_object, "docx", filename=file_name)
         file_object.close()
 
         logger.info(

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -513,7 +513,7 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any]) -> None:
                     doc.save(buffer)
                     buffer.seek(0)
 
-                    result = upload_file(buffer, "docx")
+                    result = upload_file(buffer, "docx", filename=payload.get("file_name") or _name)
                 finally:
                     buffer.close()
 

--- a/email_tools/base_email_tool.py
+++ b/email_tools/base_email_tool.py
@@ -35,7 +35,7 @@ def _load_template() -> str:
         raise
 
 
-def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="normal", language="cs-CZ"):
+def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="normal", language="cs-CZ", file_name=None):
     """Create an unsent email draft (EML) using a Mustache HTML template.
 
     Template variables:
@@ -104,7 +104,7 @@ def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="norm
         buffer.write(msg_bytes)
         buffer.seek(0)
 
-        return upload_file(buffer, "eml")
+        return upload_file(buffer, "eml", filename=file_name)
     except Exception as e:
         logger.error("Failed to create email draft: %s", e, exc_info=True)
         raise RuntimeError(f"Failed to create email draft: {e}") from e

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -153,7 +153,7 @@ def register_email_template_tools_from_yaml(mcp: FastMCP, yaml_path: Path) -> No
                         try:
                             buffer.write(msg.as_bytes())
                             buffer.seek(0)
-                            return upload_file(buffer, "eml")
+                            return upload_file(buffer, "eml", filename=safe_payload.get("file_name") or safe_payload.get("subject") or _name)
                         except Exception as e:  # pragma: no cover
                             logger.error(f"[dynamic-email] Error creating email draft for template '{_name}': {e}")
                             raise ToolError(f"Error creating email draft for template '{_name}': {e}")

--- a/main.py
+++ b/main.py
@@ -97,7 +97,8 @@ class PowerPointSlide(BaseModel):
     annotations={"title": "Markdown to Excel Converter"}
 )
 async def create_excel_document(
-    markdown_content: Annotated[str, Field(description="Markdown content containing tables, headers, and formulas. Use '## Sheet: Sheet Name' to create multiple worksheets. Use T1.B[0] for cross-table references and B[0] for current row references. Use SheetName!T1.B[0] for cross-sheet references (resolves to SheetName!B2 in Excel). ALWAYS use [0], [1], [2] notation, NEVER use absolute row numbers like B2, B3. Do NOT count table header as first row, first row has index [0]. Supports cell formatting: **bold**, *italic*.")]
+    markdown_content: Annotated[str, Field(description="Markdown content containing tables, headers, and formulas. Use '## Sheet: Sheet Name' to create multiple worksheets. Use T1.B[0] for cross-table references and B[0] for current row references. Use SheetName!T1.B[0] for cross-sheet references (resolves to SheetName!B2 in Excel). ALWAYS use [0], [1], [2] notation, NEVER use absolute row numbers like B2, B3. Do NOT count table header as first row, first row has index [0]. Supports cell formatting: **bold**, *italic*.")],
+    file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
 ) -> str:
     """
     Converts markdown to Excel with advanced formula support.
@@ -106,7 +107,7 @@ async def create_excel_document(
     logger.info("Converting markdown to Excel document")
 
     try:
-        result = markdown_to_excel(markdown_content)
+        result = markdown_to_excel(markdown_content, file_name=file_name)
         logger.info("Excel document uploaded successfully")
         return result
     except Exception as e:
@@ -160,6 +161,7 @@ async def create_word_document(
     header_text: Annotated[Optional[str], Field(description="Text for document header (top of every page). Use {page} for auto page number, {pages} for total pages.", default=None)] = None,
     footer_text: Annotated[Optional[str], Field(description="Text for document footer (bottom of every page). Use {page} for auto page number, {pages} for total pages.", default=None)] = None,
     include_toc: Annotated[Optional[bool], Field(description="If true, inserts a Table of Contents at the beginning of the document. The TOC updates automatically when opened in Word.", default=False)] = False,
+    file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
 ) -> str:
     """
     Converts markdown to professionally formatted Word document.
@@ -177,6 +179,7 @@ async def create_word_document(
             header_text=header_text,
             footer_text=footer_text,
             include_toc=include_toc or False,
+            file_name=file_name,
         )
         logger.info("Word document uploaded successfully")
         return result
@@ -208,14 +211,15 @@ All slides support optional 'speaker_notes': str field."""
     format: Annotated[Literal["4:3", "16:9"], Field(
         default="16:9",
         description="Aspect ratio: '16:9' (widescreen) or '4:3' (traditional)"
-    )] = "16:9"
+    )] = "16:9",
+    file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
 ) -> str:
     """Creates PowerPoint presentations with structured slide models and professional templates."""
 
     logger.info(f"Creating PowerPoint presentation with {len(slides)} slides in {format} format")
 
     try:
-        result = create_presentation(slides, format)
+        result = create_presentation(slides, format, file_name=file_name)
         logger.info(f"PowerPoint presentation created: {result}")
         return result
     except Exception as e:
@@ -235,7 +239,8 @@ async def create_email_draft(
     cc: Annotated[Optional[List[str]], Field(description="List of CC recipient email addresses", default=None)],
     bcc: Annotated[Optional[List[str]], Field(description="List of BCC recipient email addresses", default=None)],
     priority: Annotated[str, Field(description="Email priority: 'low', 'normal', or 'high'", default="normal")],
-    language: Annotated[str, Field(description="Language code for proofreading in Outlook (e.g., 'cs-CZ' for Czech, 'en-US' for English, 'de-DE' for German, 'sk-SK' for Slovak)", default="cs-CZ")]
+    language: Annotated[str, Field(description="Language code for proofreading in Outlook (e.g., 'cs-CZ' for Czech, 'en-US' for English, 'de-DE' for German, 'sk-SK' for Slovak)", default="cs-CZ")],
+    file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
 ) -> str:
     """
     Creates professional email drafts in EML format with preset styling and language settings.
@@ -251,7 +256,8 @@ async def create_email_draft(
             re=subject,
             content=content,
             priority=priority,
-            language=language
+            language=language,
+            file_name=file_name,
         )
         logger.info(f"Email draft created: {result}")
         return result
@@ -266,7 +272,8 @@ async def create_email_draft(
     annotations={"title": "XML File Creator"}
 )
 async def create_xml_document(
-    xml_content: Annotated[str, Field(description="Complete, well-formed XML content. Must be valid XML with proper opening and closing tags.")]
+    xml_content: Annotated[str, Field(description="Complete, well-formed XML content. Must be valid XML with proper opening and closing tags.")],
+    file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
 ) -> str:
     """
     Creates an XML file from provided XML content.
@@ -276,7 +283,7 @@ async def create_xml_document(
     logger.info("Creating XML file")
 
     try:
-        result = create_xml_file(xml_content)
+        result = create_xml_file(xml_content, file_name=file_name)
         logger.info(f"XML file created successfully.")
         return result
     except Exception as e:

--- a/pptx_tools/base_pptx_tool.py
+++ b/pptx_tools/base_pptx_tool.py
@@ -7,7 +7,7 @@ from .slide_builder import PowerpointPresentation
 logger = logging.getLogger(__name__)
 
 
-def create_presentation(slides: List[Dict[str, Any]], format: str = "4:3") -> str:
+def create_presentation(slides: List[Dict[str, Any]], format: str = "4:3", file_name: str | None = None) -> str:
     """Create a PowerPoint presentation from structured slides and upload it.
 
     :param slides: List of slide dicts with keys based on slide_type
@@ -29,7 +29,7 @@ def create_presentation(slides: List[Dict[str, Any]], format: str = "4:3") -> st
         file_object = presentation.save()
 
         # Upload presentation
-        text = upload_file(file_object, "pptx")
+        text = upload_file(file_object, "pptx", filename=file_name)
         file_object.close()
 
         logger.info("PowerPoint upload completed")

--- a/upload_tools/main.py
+++ b/upload_tools/main.py
@@ -1,6 +1,6 @@
 import logging
 from config import get_config
-from .utils import generate_unique_object_name
+from .utils import generate_unique_object_name, generate_named_object_name
 from .backends.local import upload_to_local_folder
 from .backends.s3 import upload_to_s3
 from .backends.gcs import upload_to_gcs
@@ -29,17 +29,23 @@ elif UPLOAD_STRATEGY == "MINIO":
     logger.info("MinIO upload strategy set.")
 
 
-def upload_file(file_object, suffix: str) -> str:
+def upload_file(file_object, suffix: str, filename: str | None = None) -> str:
     """Upload a file to configured backend and return appropriate response.
 
     :param file_object: File-like object to upload
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
+    :param filename: Optional human-readable filename (without extension). When provided,
+        the uploaded object will use this name (sanitized) with a short UUID prefix instead
+        of a full UUID.
     :return: Status message with download URL or save location
     :raises RuntimeError: If upload fails for any reason
     """
 
     try:
-        object_name = generate_unique_object_name(suffix)
+        if filename:
+            object_name = generate_named_object_name(filename, suffix)
+        else:
+            object_name = generate_unique_object_name(suffix)
     except Exception as e:
         logger.error("Failed to generate object name for suffix '%s': %s", suffix, e, exc_info=True)
         raise RuntimeError(f"Error preparing upload: {e}") from e

--- a/upload_tools/utils.py
+++ b/upload_tools/utils.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 
 
@@ -5,6 +6,36 @@ def generate_unique_object_name(suffix: str) -> str:
     """Generate a unique object name using UUID and preserve the file extension."""
     unique_id = str(uuid.uuid4())
     return f"{unique_id}.{suffix}"
+
+
+def sanitize_filename(name: str) -> str:
+    """Sanitize a human-readable name into a safe filename component.
+
+    Strips unsafe characters, replaces whitespace with underscores, and truncates
+    to a reasonable length.
+
+    :param name: Raw filename or title string
+    :return: Sanitized string safe for use in object/blob names
+    """
+    # Remove characters that are unsafe for filenames/URLs
+    name = re.sub(r'[^\w\s\-.]', '', name)
+    # Collapse whitespace to single underscores
+    name = re.sub(r'\s+', '_', name.strip())
+    # Truncate to 100 chars to avoid overly long names
+    name = name[:100]
+    return name or "document"
+
+
+def generate_named_object_name(filename: str, suffix: str) -> str:
+    """Generate an object name using a human-readable filename with a short UUID prefix.
+
+    :param filename: Human-readable filename (will be sanitized)
+    :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
+    :return: Object name like 'a1b2c3d4_My_Report.docx'
+    """
+    safe_name = sanitize_filename(filename)
+    short_id = uuid.uuid4().hex[:8]
+    return f"{short_id}_{safe_name}.{suffix}"
 
 
 def get_content_type(file_name: str) -> str:

--- a/xlsx_tools/base_xlsx_tool.py
+++ b/xlsx_tools/base_xlsx_tool.py
@@ -74,7 +74,7 @@ def _scan_table_positions(lines: List[str]) -> Dict[str, Dict[str, int]]:
     return all_positions
 
 
-def markdown_to_excel(markdown_content: str) -> str:
+def markdown_to_excel(markdown_content: str, file_name: str | None = None) -> str:
     """Convert Markdown to Excel workbook (focused on tables and headers).
 
     Always starts from an empty Workbook (no templates).
@@ -200,7 +200,7 @@ def markdown_to_excel(markdown_content: str) -> str:
         logger.info("Saving Excel workbook to memory buffer")
         wb.save(file_object)
         file_object.seek(0)
-        result = upload_file(file_object, "xlsx")
+        result = upload_file(file_object, "xlsx", filename=file_name)
         logger.info("Excel upload completed (headers=%d, tables=%d)", headers_count, tables_count)
         return result
     except Exception as e:

--- a/xml_tools/base_xml_tool.py
+++ b/xml_tools/base_xml_tool.py
@@ -54,7 +54,7 @@ def validate_xml(xml_content: str) -> Tuple[bool, str]:
         return False, f"Unexpected error during XML validation: {str(e)}"
 
 
-def create_xml_file(xml_content: str) -> str:
+def create_xml_file(xml_content: str, file_name: str | None = None) -> str:
     """Create an XML file from the provided XML content.
 
     Validates that the content is well-formed XML before saving.
@@ -101,7 +101,7 @@ def create_xml_file(xml_content: str) -> str:
 
         try:
             # Upload the file
-            result = upload_file(file_object, "xml")
+            result = upload_file(file_object, "xml", filename=file_name)
             logger.info("XML file uploaded successfully")
             return result
         finally:


### PR DESCRIPTION
## Summary
This PR adds an optional `file_name` parameter to all document creation tools and dynamic template tools.

If a name is provided, uploaded files will use a more readable format like `a1b2c3d4_Q1_Sales_Report.docx` instead of a long UUID-only filename. If no `file_name` is passed, the current behavior stays exactly the same.

## Why
Right now, uploaded files are stored with UUID-only names, which makes them hard to recognize when browsing storage or downloading them later.

This change makes it possible to keep filenames meaningful and easier to identify, while still preserving uniqueness.

## What changed
- Added filename sanitization and named object generation helpers
- Added an optional filename parameter to `upload_file()`
- Added `file_name` support to all static MCP document tools
- Passed `file_name` through the DOCX, PPTX, XLSX, XML, and email upload flows
- Updated dynamic DOCX tools to use `file_name`, or fall back to the template name
- Updated dynamic email tools to use `file_name`, then subject, then template name

## Filename handling
Provided filenames are sanitized before upload:
- unsafe characters are removed
- spaces are converted to underscores
- names are truncated to 100 characters
- empty results fall back to `"document"`
- an 8-character UUID prefix is added to keep names unique

## Test plan
- [ ] Create a Word document with `file_name` and verify the uploaded blob includes it
- [ ] Create a Word document without `file_name` and verify UUID naming still works
- [ ] Test special characters in `file_name` (for example: `"Report (Q1) — Final!"`) and verify sanitization
- [ ] Test each document type: DOCX, XLSX, PPTX, EML, and XML
- [ ] Test dynamic DOCX and email template tools and verify fallback naming works correctly