### PR TITLE
AWS S3 (when UPLOAD_STRATEGY=S3) options are added so that it works if explicit credentials are set or  default credential chain are used where credentials are discovered automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,22 @@ UPLOAD_STRATEGY=LOCAL
 # How long generated download links remain valid (in seconds) for S3/GCS/AZURE
 SIGNED_URL_EXPIRES_IN=3600
 
-# --- AWS S3 (required when UPLOAD_STRATEGY=S3) ---
+# --- AWS S3 (when UPLOAD_STRATEGY=S3) ---
+# S3_BUCKET is always required.
+# AWS credentials and region can be provided explicitly (Option A) or
+# resolved automatically via the AWS default credential chain (Option B).
+#
+# Option A: Explicit credentials (set all three)
+#   AWS_ACCESS_KEY=<your-access-key>
+#   AWS_SECRET_ACCESS_KEY=<your-secret-key>
+#   AWS_REGION=<e.g. us-east-1>
+#
+# Option B: Default credential chain (leave AWS_ACCESS_KEY and
+#   AWS_SECRET_ACCESS_KEY unset). Credentials are discovered automatically:
+#   - AWS SSO sessions (run "aws sso login" locally)
+#   - IRSA on EKS (IAM Roles for Service Accounts)
+#   - EC2 instance profiles, ECS task roles, environment variables, etc.
+#   AWS_REGION is optional — boto3 resolves it from env/config/metadata.
 AWS_ACCESS_KEY=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=

--- a/config.py
+++ b/config.py
@@ -77,8 +77,8 @@ class S3Settings(BaseModel):
        - **AWS SSO / ``aws sso login`` sessions** — for local
          development after running ``aws sso login``
        - ECS container credentials
-       - **IRSA (IAM Roles for Service Accounts)** — for the deployments in AWS EKS
-         when for the pods running on **AWS EKS**
+       - **IRSA (IAM Roles for Service Accounts)** — for pods running on
+         **AWS EKS**
        - EC2 instance metadata (IMDSv2)
 
     ``S3_BUCKET`` is always required regardless of the credential method.

--- a/config.py
+++ b/config.py
@@ -59,26 +59,80 @@ class LoggingSettings(BaseModel):
 
 
 class S3Settings(BaseModel):
-    """Required credentials and configuration for AWS S3 uploads."""
-    access_key: str
-    secret_key: str
-    region: str
+    """Configuration for AWS S3 uploads.
+
+    Credential resolution follows a layered approach:
+
+    1. **Explicit credentials** — Set ``AWS_ACCESS_KEY`` and
+       ``AWS_SECRET_ACCESS_KEY`` environment variables. Can be used for local
+       development or non-AWS environments. ``AWS_REGION`` is also required
+       when using explicit credentials.
+    2. **AWS default credential chain ** — When
+       the explicit credential env vars are *NOT* set, the boto3 SDK
+       automatically discovers credentials from (in order):
+       - Environment variables (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``,
+         ``AWS_SESSION_TOKEN``, ``AWS_DEFAULT_REGION``)
+       - Shared credential / config files (``~/.aws/credentials``,
+         ``~/.aws/config``)
+       - **AWS SSO / ``aws sso login`` sessions** — for local
+         development after running ``aws sso login``
+       - ECS container credentials
+       - **IRSA (IAM Roles for Service Accounts)** — for the deployments in AWS EKS
+         when for the pods running on **AWS EKS**
+       - EC2 instance metadata (IMDSv2)
+
+    ``S3_BUCKET`` is always required regardless of the credential method.
+    ``AWS_REGION`` is optional when using the default credential chain — boto3
+    will resolve the region from the environment, config files, or instance
+    metadata.
+    """
+    access_key: Optional[str] = None
+    secret_key: Optional[str] = None
+    region: Optional[str] = None
     bucket: str
 
     @model_validator(mode="after")
-    def _non_empty(self) -> "S3Settings":
-        """Ensure all S3 fields are non-empty, raising a helpful error otherwise."""
-        missing = [
-            name for name, val in (
-                ("AWS_ACCESS_KEY", self.access_key),
-                ("AWS_SECRET_ACCESS_KEY", self.secret_key),
-                ("AWS_REGION", self.region),
-                ("S3_BUCKET", self.bucket),
-            ) if not str(val).strip()
-        ]
-        if missing:
-            raise ValueError(f"Missing required S3 settings: {', '.join(missing)}")
+    def _validate(self) -> "S3Settings":
+        """Validate S3 settings.
+
+        - ``bucket`` is always required.
+        - If explicit credentials are partially provided (only one of
+          access_key / secret_key), raise an error — either provide both
+          or neither.
+        - When explicit credentials are provided, ``region`` is required
+          because we construct the endpoint URL from it.
+        """
+        # Normalize empty strings to None
+        if self.access_key is not None and not self.access_key.strip():
+            self.access_key = None
+        if self.secret_key is not None and not self.secret_key.strip():
+            self.secret_key = None
+        if self.region is not None and not self.region.strip():
+            self.region = None
+
+        if not self.bucket or not self.bucket.strip():
+            raise ValueError("Missing required S3 setting: S3_BUCKET")
+        self.bucket = self.bucket.strip()
+
+        has_key = self.access_key is not None
+        has_secret = self.secret_key is not None
+        if has_key != has_secret:
+            raise ValueError(
+                "AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY must both be set or both be omitted. "
+                "Omit both to use the AWS default credential chain (IRSA, SSO, instance profile, etc.)."
+            )
+
+        if has_key and has_secret and self.region is None:
+            raise ValueError(
+                "AWS_REGION is required when explicit AWS_ACCESS_KEY / AWS_SECRET_ACCESS_KEY are provided."
+            )
+
         return self
+
+    @property
+    def use_explicit_credentials(self) -> bool:
+        """Return True if explicit AWS credentials were provided."""
+        return self.access_key is not None and self.secret_key is not None
 
 
 class GCSSettings(BaseModel):
@@ -246,9 +300,9 @@ class Config(BaseModel):
 
         if strategy == StorageStrategy.S3.value:
             s3_settings = S3Settings(
-                access_key=os.environ.get("AWS_ACCESS_KEY", ""),
-                secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
-                region=os.environ.get("AWS_REGION", ""),
+                access_key=os.environ.get("AWS_ACCESS_KEY") or None,
+                secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY") or None,
+                region=os.environ.get("AWS_REGION") or None,
                 bucket=os.environ.get("S3_BUCKET", ""),
             )
         elif strategy == StorageStrategy.GCS.value:

--- a/config.py
+++ b/config.py
@@ -67,7 +67,7 @@ class S3Settings(BaseModel):
        ``AWS_SECRET_ACCESS_KEY`` environment variables. Can be used for local
        development or non-AWS environments. ``AWS_REGION`` is also required
        when using explicit credentials.
-    2. **AWS default credential chain ** — When
+    2. **AWS default credential chain** — When
        the explicit credential env vars are *NOT* set, the boto3 SDK
        automatically discovers credentials from (in order):
        - Environment variables (``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``,

--- a/config.py
+++ b/config.py
@@ -102,13 +102,14 @@ class S3Settings(BaseModel):
         - When explicit credentials are provided, ``region`` is required
           because we construct the endpoint URL from it.
         """
-        # Normalize empty strings to None
-        if self.access_key is not None and not self.access_key.strip():
-            self.access_key = None
-        if self.secret_key is not None and not self.secret_key.strip():
-            self.secret_key = None
-        if self.region is not None and not self.region.strip():
-            self.region = None
+        # Normalize optional strings by stripping surrounding whitespace and
+        # converting empty strings to None.
+        if self.access_key is not None:
+            self.access_key = self.access_key.strip() or None
+        if self.secret_key is not None:
+            self.secret_key = self.secret_key.strip() or None
+        if self.region is not None:
+            self.region = self.region.strip() or None
 
         if not self.bucket or not self.bucket.strip():
             raise ValueError("Missing required S3 setting: S3_BUCKET")

--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -120,6 +120,37 @@ class TestS3SettingsValidation:
         assert cfg.storage.s3.secret_key is None
         assert cfg.storage.s3.region is None
 
+    def test_whitespace_in_credentials_stripped(self):
+        """Leading/trailing whitespace in keys and region should be stripped."""
+        env = _build_env(
+            AWS_ACCESS_KEY="  AKID  ",
+            AWS_SECRET_ACCESS_KEY="  secret  ",
+            AWS_REGION="  us-east-1  ",
+            S3_BUCKET="  ws-bucket  ",
+        )
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3.access_key == "AKID"
+        assert cfg.storage.s3.secret_key == "secret"
+        assert cfg.storage.s3.region == "us-east-1"
+        assert cfg.storage.s3.bucket == "ws-bucket"
+        assert cfg.storage.s3.use_explicit_credentials is True
+
+    def test_whitespace_only_credentials_normalize_to_none(self):
+        """Whitespace-only credential strings should normalize to None (default chain)."""
+        env = _build_env(
+            AWS_ACCESS_KEY="   ",
+            AWS_SECRET_ACCESS_KEY="   ",
+            AWS_REGION="   ",
+            S3_BUCKET="ws-only-bucket",
+        )
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3.use_explicit_credentials is False
+        assert cfg.storage.s3.access_key is None
+        assert cfg.storage.s3.secret_key is None
+        assert cfg.storage.s3.region is None
+
     def test_partial_credentials_rejected(self):
         """Only one of access_key / secret_key set — should raise ValueError."""
         env = _build_env(

--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -1,0 +1,284 @@
+"""Tests for AWS S3 upload backend configuration and client creation.
+
+Validates three credential scenarios:
+1. Explicit credentials (AWS_ACCESS_KEY, AWS_SECRET_ACCESS_KEY, AWS_REGION, S3_BUCKET)
+2. Default credential chain with no creds (IRSA on EKS, SSO locally)
+3. Default credential chain with optional region override
+
+Also verifies validation rules:
+- Partial credentials (key without secret or vice versa) are rejected
+- Missing S3_BUCKET is rejected
+- Explicit credentials without AWS_REGION are rejected
+- Empty string env vars normalize to the default credential chain
+"""
+
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Env vars used by S3Settings via Config.from_env()
+S3_ENV_KEYS = [
+    "UPLOAD_STRATEGY",
+    "AWS_ACCESS_KEY",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_REGION",
+    "S3_BUCKET",
+]
+
+
+def _build_env(**overrides):
+    """Return a minimal S3 environment dict with given overrides.
+
+    Keys not in *overrides* are removed from the environment so that
+    previous test state doesn't leak.
+    """
+    env = {k: os.environ.get(k) for k in S3_ENV_KEYS}  # snapshot
+    # Clear all S3-related vars
+    clean = {k: v for k, v in os.environ.items() if k not in S3_ENV_KEYS}
+    clean["UPLOAD_STRATEGY"] = "S3"
+    clean.update(overrides)
+    return clean
+
+
+def _get_fresh_config(env: dict):
+    """Return a fresh Config from *env*, bypassing the singleton cache."""
+    import config as cfg_mod
+    cfg_mod._CONFIG = None
+    with patch.dict(os.environ, env, clear=True):
+        return cfg_mod.get_config()
+
+
+# ---------------------------------------------------------------------------
+# S3Settings validation tests
+# ---------------------------------------------------------------------------
+
+class TestS3SettingsValidation:
+    """Test S3Settings Pydantic model validation rules."""
+
+    def test_explicit_credentials_all_set(self):
+        """All four env vars provided — classic / original behaviour."""
+        env = _build_env(
+            AWS_ACCESS_KEY="<TEST_AWS_ACCESS_KEY>",
+            AWS_SECRET_ACCESS_KEY="<TEST_AWS_SECRET_KEY>",
+            AWS_REGION="us-east-1",
+            S3_BUCKET="my-test-bucket",
+        )
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3 is not None
+        assert cfg.storage.s3.use_explicit_credentials is True
+        assert cfg.storage.s3.access_key == "<TEST_AWS_ACCESS_KEY>"
+        assert cfg.storage.s3.secret_key == "<TEST_AWS_SECRET_KEY>"
+        assert cfg.storage.s3.region == "us-east-1"
+        assert cfg.storage.s3.bucket == "my-test-bucket"
+
+    def test_default_chain_no_credentials(self):
+        """Only S3_BUCKET set — should use default credential chain (IRSA / SSO)."""
+        env = _build_env(S3_BUCKET="irsa-bucket")
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3 is not None
+        assert cfg.storage.s3.use_explicit_credentials is False
+        assert cfg.storage.s3.access_key is None
+        assert cfg.storage.s3.secret_key is None
+        assert cfg.storage.s3.region is None
+        assert cfg.storage.s3.bucket == "irsa-bucket"
+
+    def test_default_chain_with_region(self):
+        """S3_BUCKET + AWS_REGION set, no credentials — region is passed through."""
+        env = _build_env(AWS_REGION="eu-west-1", S3_BUCKET="regional-bucket")
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3.use_explicit_credentials is False
+        assert cfg.storage.s3.region == "eu-west-1"
+        assert cfg.storage.s3.bucket == "regional-bucket"
+
+    def test_empty_strings_normalize_to_default_chain(self):
+        """Empty-string env vars should behave as if unset."""
+        env = _build_env(
+            AWS_ACCESS_KEY="",
+            AWS_SECRET_ACCESS_KEY="",
+            AWS_REGION="",
+            S3_BUCKET="empty-strings-bucket",
+        )
+        cfg = _get_fresh_config(env)
+
+        assert cfg.storage.s3.use_explicit_credentials is False
+        assert cfg.storage.s3.access_key is None
+        assert cfg.storage.s3.secret_key is None
+        assert cfg.storage.s3.region is None
+
+    def test_partial_credentials_rejected(self):
+        """Only one of access_key / secret_key set — should raise ValueError."""
+        env = _build_env(
+            AWS_ACCESS_KEY="AKID",
+            AWS_REGION="us-east-1",
+            S3_BUCKET="partial-bucket",
+        )
+        with pytest.raises(ValueError, match="both be set or both be omitted"):
+            _get_fresh_config(env)
+
+    def test_missing_bucket_rejected(self):
+        """Empty S3_BUCKET should raise ValueError."""
+        env = _build_env(S3_BUCKET="")
+        with pytest.raises(ValueError, match="S3_BUCKET"):
+            _get_fresh_config(env)
+
+    def test_explicit_credentials_without_region_rejected(self):
+        """Explicit credentials without AWS_REGION should raise ValueError."""
+        env = _build_env(
+            AWS_ACCESS_KEY="AKID",
+            AWS_SECRET_ACCESS_KEY="secret",
+            S3_BUCKET="no-region-bucket",
+        )
+        with pytest.raises(ValueError, match="AWS_REGION is required"):
+            _get_fresh_config(env)
+
+
+# ---------------------------------------------------------------------------
+# S3 client creation tests
+# ---------------------------------------------------------------------------
+
+class TestS3ClientCreation:
+    """Test _create_s3_client builds the boto3 client correctly."""
+
+    def test_client_with_explicit_credentials(self):
+        """Explicit credentials → boto3.client called with access key, secret, region, endpoint."""
+        env = _build_env(
+            AWS_ACCESS_KEY="AKID",
+            AWS_SECRET_ACCESS_KEY="secret",
+            AWS_REGION="us-west-2",
+            S3_BUCKET="explicit-bucket",
+        )
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        with patch("boto3.client", return_value=mock_client) as patched:
+            from upload_tools.backends.s3 import _create_s3_client
+            result = _create_s3_client(cfg.storage.s3)
+
+            patched.assert_called_once_with(
+                's3',
+                region_name="us-west-2",
+                aws_access_key_id="AKID",
+                aws_secret_access_key="secret",
+                endpoint_url="https://s3.us-west-2.amazonaws.com",
+            )
+            assert result is mock_client
+
+    def test_client_with_default_chain_no_region(self):
+        """Default chain, no region → boto3.client called with no extra kwargs."""
+        env = _build_env(S3_BUCKET="chain-bucket")
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        with patch("boto3.client", return_value=mock_client) as patched:
+            from upload_tools.backends.s3 import _create_s3_client
+            result = _create_s3_client(cfg.storage.s3)
+
+            patched.assert_called_once_with('s3')
+            assert result is mock_client
+
+    def test_client_with_default_chain_and_region(self):
+        """Default chain + region → boto3.client called with region_name only."""
+        env = _build_env(AWS_REGION="ap-southeast-1", S3_BUCKET="region-chain-bucket")
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        with patch("boto3.client", return_value=mock_client) as patched:
+            from upload_tools.backends.s3 import _create_s3_client
+            result = _create_s3_client(cfg.storage.s3)
+
+            patched.assert_called_once_with('s3', region_name="ap-southeast-1")
+            assert result is mock_client
+
+
+# ---------------------------------------------------------------------------
+# upload_to_s3 integration tests (mocked boto3)
+# ---------------------------------------------------------------------------
+
+class TestUploadToS3:
+    """Test the upload_to_s3 function end-to-end with mocked boto3."""
+
+    def test_upload_returns_presigned_url(self):
+        """Successful upload should return a string with the presigned URL."""
+        from io import BytesIO
+        from upload_tools.backends.s3 import upload_to_s3
+
+        env = _build_env(S3_BUCKET="upload-bucket")
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        mock_client.generate_presigned_url.return_value = "https://s3.amazonaws.com/upload-bucket/test.docx?signed"
+
+        with patch("upload_tools.backends.s3._create_s3_client", return_value=mock_client):
+            file_obj = BytesIO(b"test content")
+            result = upload_to_s3(file_obj, "test.docx", cfg.storage.s3, 3600)
+
+        assert result is not None
+        assert "https://s3.amazonaws.com/upload-bucket/test.docx?signed" in result
+        assert "3600 seconds" in result
+
+        mock_client.upload_fileobj.assert_called_once()
+        mock_client.generate_presigned_url.assert_called_once_with(
+            'get_object',
+            Params={'Bucket': 'upload-bucket', 'Key': 'test.docx'},
+            ExpiresIn=3600,
+        )
+
+    def test_upload_returns_none_when_no_config(self):
+        """upload_to_s3 should return None when s3cfg is None."""
+        from upload_tools.backends.s3 import upload_to_s3
+        from io import BytesIO
+
+        result = upload_to_s3(BytesIO(b"data"), "file.docx", None, 3600)
+        assert result is None
+
+    def test_upload_returns_none_on_no_credentials_error(self):
+        """upload_to_s3 should return None and log when credentials are missing."""
+        from io import BytesIO
+        from botocore.exceptions import NoCredentialsError
+        from upload_tools.backends.s3 import upload_to_s3
+
+        env = _build_env(S3_BUCKET="no-creds-bucket")
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        mock_client.upload_fileobj.side_effect = NoCredentialsError()
+
+        with patch("upload_tools.backends.s3._create_s3_client", return_value=mock_client):
+            result = upload_to_s3(BytesIO(b"data"), "file.docx", cfg.storage.s3, 3600)
+
+        assert result is None
+
+    def test_upload_returns_none_on_client_error(self):
+        """upload_to_s3 should return None on ClientError."""
+        from io import BytesIO
+        from botocore.exceptions import ClientError
+        from upload_tools.backends.s3 import upload_to_s3
+
+        env = _build_env(S3_BUCKET="error-bucket")
+        cfg = _get_fresh_config(env)
+
+        mock_client = MagicMock()
+        mock_client.upload_fileobj.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}},
+            "PutObject",
+        )
+
+        with patch("upload_tools.backends.s3._create_s3_client", return_value=mock_client):
+            result = upload_to_s3(BytesIO(b"data"), "file.docx", cfg.storage.s3, 3600)
+
+        assert result is None

--- a/upload_tools/backends/s3.py
+++ b/upload_tools/backends/s3.py
@@ -1,43 +1,120 @@
+"""AWS S3 upload backend.
+
+Supports two credential modes:
+
+1. **Explicit credentials** — ``AWS_ACCESS_KEY``, ``AWS_SECRET_ACCESS_KEY``,
+   and ``AWS_REGION`` are set as environment variables. The S3 client is
+   created with these values directly.
+
+2. **AWS default credential chain** — When the above env vars are *not* set,
+   ``boto3`` automatically discovers credentials from the standard chain:
+
+   - Environment variables (``AWS_ACCESS_KEY_ID``, etc.)
+   - Shared credential / config files (``~/.aws/credentials``)
+   - AWS SSO sessions (``aws sso login``) — for local development
+   - ECS container credentials
+   - **IRSA (IAM Roles for Service Accounts)** — for AWS EKS
+   - EC2 instance metadata (IMDSv2)
+
+   This mode requires no credential env vars at all; only ``S3_BUCKET`` is
+   needed. Region is resolved automatically from the environment, AWS config,
+   or instance metadata.
+
+See Also:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+"""
+
 import logging
 from ..utils import get_content_type
 
 logger = logging.getLogger(__name__)
 
 
+def _create_s3_client(s3cfg):
+    """Create a boto3 S3 client using either explicit or default credentials.
+
+    Args:
+        s3cfg: An ``S3Settings`` instance from config.
+
+    Returns:
+        A boto3 S3 client ready for use.
+
+    When ``s3cfg.use_explicit_credentials`` is True, the client is created
+    with the provided access key, secret key, region, and a region-specific
+    endpoint URL.
+
+    When explicit credentials are not provided, boto3's default credential
+    chain is used. This automatically supports:
+
+    - IRSA on EKS (via ``AWS_WEB_IDENTITY_TOKEN_FILE`` and
+      ``AWS_ROLE_ARN`` injected by the EKS pod identity webhook)
+    - AWS SSO sessions (after running ``aws sso login``)
+    - Instance profiles, environment variables, config files, etc.
+    """
+    import boto3  # type: ignore
+
+    if s3cfg.use_explicit_credentials:
+        logger.info("Creating S3 client with explicit credentials (region: %s)", s3cfg.region)
+        return boto3.client(
+            's3',
+            region_name=s3cfg.region,
+            aws_access_key_id=s3cfg.access_key,
+            aws_secret_access_key=s3cfg.secret_key,
+            endpoint_url=f'https://s3.{s3cfg.region}.amazonaws.com',
+        )
+
+    # Use the default credential chain (IRSA, SSO, instance profile, etc.)
+    logger.info(
+        "Creating S3 client using default credential chain (region: %s)",
+        s3cfg.region or "auto-detected",
+    )
+    client_kwargs = {"region_name": s3cfg.region} if s3cfg.region else {}
+    return boto3.client('s3', **client_kwargs)
+
+
 def upload_to_s3(file_object, file_name: str, s3cfg, signed_url_expires_in: int):
+    """Upload a file to S3 and return a pre-signed download URL.
+
+    Args:
+        file_object: A file-like object (must support ``seek`` and ``read``).
+        file_name: The S3 object key (destination path/name in the bucket).
+        s3cfg: An ``S3Settings`` instance with bucket and optional credentials.
+        signed_url_expires_in: TTL in seconds for the pre-signed download URL.
+
+    Returns:
+        A string containing the pre-signed URL and expiry info, or ``None``
+        on failure.
+    """
     if not s3cfg:
         logger.error("S3 configuration not provided")
         return None
 
-    # Lazy import to avoid requiring boto3 unless S3 strategy is used
+    # Lazy import to avoid requiring boto3/botocore unless S3 strategy is used
     try:
-        import boto3  # type: ignore
         from botocore.exceptions import NoCredentialsError, ClientError  # type: ignore
-    except Exception as e:
+    except Exception:
         logger.error("boto3/botocore are not installed. Please add them to requirements and install.")
         return None
 
     content_type = get_content_type(file_name)
 
     try:
-        # Create an S3 client
-        s3_client = boto3.client(
-            's3',
-            region_name=s3cfg.region,
-            aws_access_key_id=s3cfg.access_key,
-            aws_secret_access_key=s3cfg.secret_key,
-            endpoint_url=f'https://s3.{s3cfg.region}.amazonaws.com'
-        )
+        s3_client = _create_s3_client(s3cfg)
 
         # Upload the file to S3
         file_object.seek(0)
-        s3_client.upload_fileobj(Fileobj=file_object, Bucket=s3cfg.bucket, Key=file_name, ExtraArgs={'ContentType': content_type})
+        s3_client.upload_fileobj(
+            Fileobj=file_object,
+            Bucket=s3cfg.bucket,
+            Key=file_name,
+            ExtraArgs={'ContentType': content_type},
+        )
 
         # Generate a pre-signed URL valid for configured duration
         url = s3_client.generate_presigned_url(
             'get_object',
             Params={'Bucket': s3cfg.bucket, 'Key': file_name},
-            ExpiresIn=signed_url_expires_in
+            ExpiresIn=signed_url_expires_in,
         )
 
         return f"Link to created document to be shared with user in markdown format: {url} . Link is valid for {signed_url_expires_in} seconds."
@@ -46,7 +123,12 @@ def upload_to_s3(file_object, file_name: str, s3cfg, signed_url_expires_in: int)
         logger.error(f"The file {file_object} was not found.")
         return None
     except NoCredentialsError:
-        logger.error("AWS credentials are not available.")
+        logger.error(
+            "AWS credentials are not available. When running without explicit "
+            "AWS_ACCESS_KEY / AWS_SECRET_ACCESS_KEY, ensure credentials are "
+            "available via the AWS default credential chain: IRSA (EKS), "
+            "aws sso login (local), instance profile, or ~/.aws/credentials."
+        )
         return None
     except ClientError as e:
         logger.error(f"Client error: {e}")


### PR DESCRIPTION
AWS S3 (when UPLOAD_STRATEGY=S3) options are added so that it works if explicit credentials are set or  default credential chain (leave AWS_ACCESS_KEY and AWS_SECRET_ACCESS_KEY unset) are used where credentials are discovered automatically (e.g., IRSA on EKS, EC2 instance profiles, ECS task roles etc.)