### PR TITLE
a configurable async_runner of mcp tool functions are added as wrapper so that event loop doesn't get stuck on long processing work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,19 @@ DEBUG=
 # Leave empty to disable authentication.
 API_KEY=
 
+# --- Runtime: blocking-call offload ---
+# When truthy (1, true, yes, on), MCP tool handlers dispatch their
+# synchronous document-generation work to a worker thread via
+# asyncio.to_thread, keeping the FastMCP event loop free to serve health
+# probes (/healthz, /readyz, /livez) and concurrent requests. This is
+# recommended for production EKS deployments where slow tool calls (large
+# markdown, image downloads, S3 uploads) can otherwise trigger liveness
+# probe timeouts and pod restarts.
+#
+# When unset or falsy (default), tools run inline on the event loop —
+# preserving the original blocking behavior.
+RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=
+
 # --- Storage / Upload strategy ---
 # One of: LOCAL, S3, GCS, AZURE
 UPLOAD_STRATEGY=LOCAL

--- a/.env.example
+++ b/.env.example
@@ -16,17 +16,26 @@ DEBUG=
 API_KEY=
 
 # --- Runtime: blocking-call offload ---
-# When truthy (1, true, yes, on), MCP tool handlers dispatch their
-# synchronous document-generation work to a worker thread via
-# asyncio.to_thread, keeping the FastMCP event loop free to serve health
-# probes (/healthz, /readyz, /livez) and concurrent requests. This is
-# recommended for production EKS deployments where slow tool calls (large
-# markdown, image downloads, S3 uploads) can otherwise trigger liveness
-# probe timeouts and pod restarts.
+# When truthy or unset (DEFAULT: enabled), MCP tool handlers dispatch
+# their synchronous document-generation work to a bounded worker thread
+# pool, keeping the FastMCP event loop free to serve health probes
+# (/healthz, /readyz, /livez) and concurrent requests. Recommended for
+# all environments — especially production EKS where slow tool calls
+# (large markdown, image downloads, S3 uploads) would otherwise trigger
+# liveness-probe timeouts and pod restarts.
 #
-# When unset or falsy (default), tools run inline on the event loop —
-# preserving the original blocking behavior.
+# Set explicitly to 'false' / '0' / 'no' / 'off' to disable (tools then
+# run inline on the event loop — useful only for local debugging).
 RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=
+
+# Maximum concurrent worker threads in the bounded ThreadPoolExecutor used
+# by run_blocking(). Lower values reduce GIL contention for CPU-bound work
+# (markdown parsing); higher values allow more concurrent I/O-bound work
+# (S3 upload, image download). Default 4 is tuned for 1 vCPU EKS pods:
+# one thread doing CPU-bound parsing under the GIL while up to three
+# others handle I/O. Excess concurrent calls queue cleanly in the
+# executor instead of fanning out and starving each other.
+RUN_BLOCKING_MAX_WORKERS=
 
 # --- Storage / Upload strategy ---
 # One of: LOCAL, S3, GCS, AZURE

--- a/async_runner.py
+++ b/async_runner.py
@@ -1,0 +1,104 @@
+"""Async-safe wrapper for blocking document-generation calls.
+
+Every Office-document generator in this project (``markdown_to_word``,
+``markdown_to_excel``, ``create_presentation``, ``create_eml``,
+``create_xml_file``, and every dynamically-registered template tool) is a
+synchronous, blocking function. They perform:
+
+  * file I/O (opening .docx / .pptx templates, which are zip archives)
+  * CPU-bound markdown / mustache rendering
+  * synchronous network I/O (``requests.get`` for image downloads,
+    ``boto3`` S3 uploads)
+
+FastMCP runs on top of an asyncio event loop (uvicorn / Starlette).
+Calling a blocking function directly from an ``async def`` MCP tool
+handler freezes the loop for the full duration of the call — no other
+request can be served, including the Kubernetes liveness / readiness
+probes. Repeated probe timeouts cause kubelet to SIGTERM the pod, which
+is the failure mode observed in EKS:
+
+    ERROR: ASGI callable returned without completing response.
+    ERROR: Cancel 0 running task(s), timeout graceful shutdown exceeded
+
+(The "0 running tasks" line is the giveaway: there were no async tasks
+because the work was running synchronously on the event loop itself.)
+
+Whether blocking work is offloaded to a worker thread is controlled by
+the ``RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED`` environment variable
+(see ``config.Config.run_blocking_by_asyncio_thread_enabled``):
+
+  * Disabled (default) — call the sync function inline on the event
+    loop. The loop is blocked until the call returns. This is the
+    legacy behaviour for static tools; dynamic tools (previously
+    registered as sync ``def`` and auto-threaded by FastMCP) will also
+    run on the event loop in this mode, since the dynamic handlers are
+    now ``async def`` wrappers around ``run_blocking``.
+  * Enabled — dispatch the sync function to asyncio's default thread
+    pool via ``asyncio.to_thread``. The event loop stays free to serve
+    health probes and concurrent requests. Recommended for EKS.
+
+All tool call sites uniformly write ``await run_blocking(func, *args,
+**kwargs)`` — the helper internally chooses the dispatch strategy based
+on config, so call sites never branch on the flag.
+
+This helper lives in its own module (not inside ``main.py``) so that
+dynamically-registered tool modules can import it without creating a
+circular dependency back through ``main``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from typing import Callable, TypeVar
+
+from config import get_config
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
+    """Run a synchronous callable, optionally on a worker thread.
+
+    Dispatch is governed by ``config.run_blocking_by_asyncio_thread_enabled``
+    (env var ``RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED``):
+
+    * **Enabled** — the call is offloaded to asyncio's default thread
+      pool via ``asyncio.to_thread``. The event loop remains responsive
+      to health probes and concurrent requests while ``func`` runs.
+    * **Disabled (default)** — the call runs inline on the event loop,
+      preserving the original blocking behaviour. ``func``'s return
+      value is returned without ever yielding to the loop.
+
+    The signature is identical in both modes — call sites always write
+    ``await run_blocking(func, *args, **kwargs)``.
+
+    Args:
+        func: The blocking function to execute.
+        *args: Positional arguments forwarded to ``func``.
+        **kwargs: Keyword arguments forwarded to ``func``.
+
+    Returns:
+        Whatever ``func`` returns.
+
+    Raises:
+        Any exception ``func`` raises propagates to the caller. In
+        threaded mode the exception is marshalled back from the worker
+        thread by ``asyncio.to_thread`` automatically.
+    """
+    # Read the flag lazily, on every call, so that tests (or admins)
+    # that mutate the config singleton between calls see the new value
+    # without having to reload this module.
+    if get_config().run_blocking_by_asyncio_thread_enabled:
+        logger.info("MZA: %s is running by asyncio.to_thread", func.__name__)
+        # functools.partial binds kwargs cleanly; asyncio.to_thread accepts
+        # *args/**kwargs directly, but going through partial keeps the
+        # call site readable and makes the closure easy to log if needed.
+        bound = functools.partial(func, *args, **kwargs)
+        return await asyncio.to_thread(bound)
+
+    # Legacy path: call inline on the event loop (blocks until done).
+    return func(*args, **kwargs)

--- a/async_runner.py
+++ b/async_runner.py
@@ -51,7 +51,9 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
-from typing import Callable, TypeVar
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Optional, TypeVar
 
 from config import get_config
 
@@ -60,15 +62,75 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+# ---------------------------------------------------------------------------
+# Bounded ThreadPoolExecutor singleton
+# ---------------------------------------------------------------------------
+# Why a bounded executor (instead of `asyncio.to_thread`'s default)?
+#
+# `asyncio.to_thread` runs on Python's default executor whose
+# ``max_workers = min(32, os.cpu_count() + 4)``. On EKS, ``os.cpu_count()``
+# returns the **host's** core count (not the pod CPU limit), so the default
+# can spawn ~32 worker threads on a 1-vCPU pod. For CPU-bound, pure-Python
+# work (such as ``markdown_to_word`` parsing) the GIL serialises all of
+# them onto a single core anyway, and each thread receives only a small
+# slice of CPU. Concurrent requests pile up and every one of them takes
+# 10×+ longer than it should — exceeding the client's timeout while the
+# event loop stays "healthy".
+#
+# A bounded executor with a small ``max_workers`` (default 4 for a 1 vCPU
+# pod) keeps concurrent work to a level the GIL can actually progress
+# through:
+#
+#   * 1 thread holds the GIL doing CPU work (markdown parsing)
+#   * up to 3 others can be in I/O (S3 upload / image download) — they
+#     release the GIL while blocked on syscalls
+#   * additional requests queue cleanly in the executor's work queue
+#     instead of fanning out and starving each other
+#
+# Tunable via ``RUN_BLOCKING_MAX_WORKERS`` (see config.Config). Recreate
+# the executor by deleting this module from ``sys.modules`` (tests do
+# this through their reload helper).
+# ---------------------------------------------------------------------------
+
+_EXECUTOR: Optional[ThreadPoolExecutor] = None
+_EXECUTOR_LOCK = threading.Lock()
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    """Return the process-wide bounded executor, creating it on first use.
+
+    Thread-safe double-checked locking pattern: the fast path requires no
+    lock acquisition once the executor exists.
+    """
+    global _EXECUTOR
+    if _EXECUTOR is None:
+        with _EXECUTOR_LOCK:
+            if _EXECUTOR is None:
+                max_workers = get_config().run_blocking_max_workers
+                _EXECUTOR = ThreadPoolExecutor(
+                    max_workers=max_workers,
+                    thread_name_prefix="run_blocking",
+                )
+                logger.info(
+                    "[run_blocking] bounded ThreadPoolExecutor created max_workers=%d",
+                    max_workers,
+                )
+    return _EXECUTOR
+
+
 async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
-    """Run a synchronous callable, optionally on a worker thread.
+    """Run a synchronous callable, optionally on a bounded worker thread.
 
     Dispatch is governed by ``config.run_blocking_by_asyncio_thread_enabled``
     (env var ``RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED``):
 
-    * **Enabled** — the call is offloaded to asyncio's default thread
-      pool via ``asyncio.to_thread``. The event loop remains responsive
-      to health probes and concurrent requests while ``func`` runs.
+    * **Enabled** — the call is submitted to a process-wide
+      ``ThreadPoolExecutor`` whose size is controlled by
+      ``config.run_blocking_max_workers`` (default 4). The event loop
+      remains responsive to health probes and concurrent requests while
+      ``func`` runs; when the pool is full, additional calls queue
+      cleanly instead of spawning unbounded threads that would all
+      contend for the GIL.
     * **Disabled (default)** — the call runs inline on the event loop,
       preserving the original blocking behaviour. ``func``'s return
       value is returned without ever yielding to the loop.
@@ -87,18 +149,18 @@ async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
     Raises:
         Any exception ``func`` raises propagates to the caller. In
         threaded mode the exception is marshalled back from the worker
-        thread by ``asyncio.to_thread`` automatically.
+        thread automatically by ``loop.run_in_executor``.
     """
     # Read the flag lazily, on every call, so that tests (or admins)
     # that mutate the config singleton between calls see the new value
     # without having to reload this module.
     if get_config().run_blocking_by_asyncio_thread_enabled:
-        logger.debug("%s is running by asyncio.to_thread", func.__name__)
-        # functools.partial binds kwargs cleanly; asyncio.to_thread accepts
-        # *args/**kwargs directly, but going through partial keeps the
-        # call site readable and makes the closure easy to log if needed.
+        logger.debug("%s is running on bounded executor", func.__name__)
+        # functools.partial binds kwargs cleanly; run_in_executor only
+        # accepts positional args, so partial is required (not optional).
         bound = functools.partial(func, *args, **kwargs)
-        return await asyncio.to_thread(bound)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(_get_executor(), bound)
 
     # Legacy path: call inline on the event loop (blocks until done).
     return func(*args, **kwargs)

--- a/async_runner.py
+++ b/async_runner.py
@@ -93,7 +93,7 @@ async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
     # that mutate the config singleton between calls see the new value
     # without having to reload this module.
     if get_config().run_blocking_by_asyncio_thread_enabled:
-        logger.info("MZA: %s is running by asyncio.to_thread", func.__name__)
+        logger.debug("%s is running by asyncio.to_thread", func.__name__)
         # functools.partial binds kwargs cleanly; asyncio.to_thread accepts
         # *args/**kwargs directly, but going through partial keeps the
         # call site readable and makes the closure easy to log if needed.

--- a/config.py
+++ b/config.py
@@ -263,6 +263,18 @@ class Config(BaseModel):
         default=None,
         description="API key for authenticating incoming requests. None means no auth.",
     )
+    run_blocking_by_asyncio_thread_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, MCP tool handlers dispatch their synchronous "
+            "document-generation work to a worker thread via "
+            "asyncio.to_thread, keeping the FastMCP event loop free to "
+            "serve health probes and concurrent requests. When False "
+            "(default), tools run inline on the event loop — preserving "
+            "the original blocking behavior. Toggled via the "
+            "RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED environment variable."
+        ),
+    )
 
     @staticmethod
     def _parse_bool(value: Optional[str]) -> bool:
@@ -341,8 +353,17 @@ class Config(BaseModel):
         # API key authentication (optional – empty/missing means no auth)
         raw_api_key = (os.environ.get("API_KEY") or "").strip() or None
 
+        # Toggle for thread-pool offload of blocking tool work.
+        # Default False preserves the legacy inline-blocking behavior.
+        run_blocking_by_asyncio_thread_enabled = cls._parse_bool(os.environ.get("RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED"))
+
         try:
-            return cls(logging=logging_settings, storage=storage_settings, api_key=raw_api_key)
+            return cls(
+                logging=logging_settings,
+                storage=storage_settings,
+                api_key=raw_api_key,
+                run_blocking_by_asyncio_thread_enabled=run_blocking_by_asyncio_thread_enabled,
+            )
         except ValidationError as e:
             # Wrap Pydantic validation errors in a simpler exception for callers
             raise ValueError(f"Invalid configuration: {e}")

--- a/config.py
+++ b/config.py
@@ -264,15 +264,30 @@ class Config(BaseModel):
         description="API key for authenticating incoming requests. None means no auth.",
     )
     run_blocking_by_asyncio_thread_enabled: bool = Field(
-        default=False,
+        default=True,
         description=(
-            "When True, MCP tool handlers dispatch their synchronous "
-            "document-generation work to a worker thread via "
-            "asyncio.to_thread, keeping the FastMCP event loop free to "
-            "serve health probes and concurrent requests. When False "
-            "(default), tools run inline on the event loop — preserving "
-            "the original blocking behavior. Toggled via the "
+            "When True (default), MCP tool handlers dispatch their "
+            "synchronous document-generation work to a bounded worker "
+            "thread pool, keeping the FastMCP event loop free to serve "
+            "health probes and concurrent requests. When False, tools "
+            "run inline on the event loop — the original blocking "
+            "behaviour (useful only for local debugging or to confirm a "
+            "regression is caused by threading). Toggled via the "
             "RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED environment variable."
+        ),
+    )
+    run_blocking_max_workers: int = Field(
+        default=4,
+        gt=0,
+        description=(
+            "Maximum concurrent worker threads in the bounded "
+            "ThreadPoolExecutor used by run_blocking(). Lower values "
+            "reduce GIL contention for CPU-bound work (markdown parsing); "
+            "higher values allow more concurrent I/O-bound work (S3 "
+            "upload). The default of 4 is tuned for 1 vCPU EKS pods: one "
+            "thread doing CPU-bound parsing under the GIL while up to "
+            "three others handle I/O. Tune via the "
+            "RUN_BLOCKING_MAX_WORKERS environment variable."
         ),
     )
 
@@ -353,9 +368,25 @@ class Config(BaseModel):
         # API key authentication (optional – empty/missing means no auth)
         raw_api_key = (os.environ.get("API_KEY") or "").strip() or None
 
-        # Toggle for thread-pool offload of blocking tool work.
-        # Default False preserves the legacy inline-blocking behavior.
-        run_blocking_by_asyncio_thread_enabled = cls._parse_bool(os.environ.get("RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED"))
+        # Toggle for thread-pool offload of blocking tool work. Default
+        # True — when the env var is absent or empty we treat it as
+        # "unset, use default". Set the var to "false"/"0"/"no"/"off" to
+        # explicitly disable (e.g. for local debugging).
+        raw_offload = os.environ.get("RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED")
+        if raw_offload is None or not raw_offload.strip():
+            run_blocking_by_asyncio_thread_enabled = True
+        else:
+            run_blocking_by_asyncio_thread_enabled = cls._parse_bool(raw_offload)
+
+        # Bounded executor size. Invalid / non-positive values silently
+        # fall back to the default (4) — tuned for 1 vCPU EKS pods.
+        raw_workers = os.environ.get("RUN_BLOCKING_MAX_WORKERS")
+        try:
+            run_blocking_max_workers = int(raw_workers) if raw_workers is not None and raw_workers.strip() else 4
+            if run_blocking_max_workers < 1:
+                run_blocking_max_workers = 4
+        except (ValueError, TypeError):
+            run_blocking_max_workers = 4
 
         try:
             return cls(
@@ -363,6 +394,7 @@ class Config(BaseModel):
                 storage=storage_settings,
                 api_key=raw_api_key,
                 run_blocking_by_asyncio_thread_enabled=run_blocking_by_asyncio_thread_enabled,
+                run_blocking_max_workers=run_blocking_max_workers,
             )
         except ValidationError as e:
             # Wrap Pydantic validation errors in a simpler exception for callers

--- a/docx_tools/base_docx_tool.py
+++ b/docx_tools/base_docx_tool.py
@@ -1,6 +1,5 @@
 import io
 import logging
-import re
 from docx import Document
 
 from upload_tools import upload_file
@@ -13,8 +12,10 @@ from .helpers import (
     add_horizontal_line,
     add_image_to_doc,
     IMAGE_PATTERN,
+    ORDERED_LIST_PATTERN,
     PAGE_BREAK_PATTERN,
     HORIZONTAL_LINE_PATTERN,
+    UNORDERED_LIST_PATTERN,
     detect_alignment,
     process_alignment_block,
     set_header_footer,
@@ -62,6 +63,9 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
 
     # Split content into lines, but preserve line breaks within paragraphs
     lines = markdown_content.split('\n')
+    # Cache len(lines) once — the list is not mutated inside the parsing
+    # loop; this removes a function call per iteration in two nested loops.
+    n = len(lines)
     i = 0
 
     # Simple parsing counters for summary
@@ -73,16 +77,19 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
     paragraphs_count = 0
 
     try:
-        while i < len(lines):
+        while i < n:
             line = lines[i]
 
-            # Handle multiple empty lines (preserve spacing)
+            # Handle multiple empty lines (preserve spacing).
+            # The outer `if` already established that lines[i] is empty;
+            # initialise the counter to 1 and advance once before entering
+            # the inner loop so we don't re-strip the same line.
             if not line.strip():
-                empty_line_count = 0
-                start_empty = i
+                empty_line_count = 1
+                i += 1
 
-                # Count consecutive empty lines
-                while i < len(lines) and not lines[i].strip():
+                # Count consecutive empty lines that follow
+                while i < n and not lines[i].strip():
                     empty_line_count += 1
                     i += 1
 
@@ -99,7 +106,7 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
             if line.endswith('  '):
                 # Collect lines that are part of the same paragraph (connected by line breaks)
                 paragraph_lines = []
-                while i < len(lines):
+                while i < n:
                     current_line = lines[i]
                     if not current_line.strip():
                         break
@@ -114,8 +121,11 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
                 first_line = paragraph_lines[0].strip()
 
                 if first_line.startswith('#'):
-                    header_level = len(first_line) - len(first_line.lstrip('#'))
-                    header_text = first_line.lstrip('#').strip()
+                    # Compute lstrip once and reuse for both the level (count
+                    # of leading '#') and the header text.
+                    stripped_hashes = first_line.lstrip('#')
+                    header_level = len(first_line) - len(stripped_hashes)
+                    header_text = stripped_hashes.strip()
                     heading = doc.add_heading('', level=min(header_level, 6))
                     parse_inline_formatting(header_text, heading)
                     headers_count += 1
@@ -135,8 +145,10 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
             line = line.strip()
 
             if line.startswith('#'):
-                header_level = len(line) - len(line.lstrip('#'))
-                header_text = line.lstrip('#').strip()
+                # Compute lstrip once (see comment above).
+                stripped_hashes = line.lstrip('#')
+                header_level = len(line) - len(stripped_hashes)
+                header_text = stripped_hashes.strip()
                 heading = doc.add_heading('', level=min(header_level, 6))
                 parse_inline_formatting(header_text, heading)
                 headers_count += 1
@@ -150,11 +162,11 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
                     tables_count += 1
                     logger.debug(f"Added table with {len(table_data)} rows")
 
-            elif re.match(r'^\d+\.\s+', line):
+            elif ORDERED_LIST_PATTERN.match(line):
                 i, _ = process_list_items(lines, i, doc, True, 0)
                 ordered_lists += 1
 
-            elif re.match(r'^[-*+]\s+', line):
+            elif UNORDERED_LIST_PATTERN.match(line):
                 i, _ = process_list_items(lines, i, doc, False, 0)
                 unordered_lists += 1
 

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -43,6 +43,7 @@ from fastmcp import FastMCP
 
 from upload_tools import upload_file
 from template_utils import find_file_in_template_dirs
+from async_runner import run_blocking
 from .helpers import (
     parse_inline_formatting,
     contains_block_markdown,
@@ -493,9 +494,20 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any]) -> None:
     model = create_model(f"{name}_DocxArgs", **fields)  # type: ignore
     globals()[model.__name__] = model
 
-    # Create the tool function
+    # Create the tool function.
+    #
+    # The tool body (`_sync_impl`) is synchronous and performs blocking
+    # work: opening the .docx zip, mustache-style placeholder
+    # substitution, and synchronous upload to the configured backend.
+    # It is wrapped in an `async def` (`tool_impl`) that dispatches the
+    # call through `run_blocking()`, so the work either runs on a
+    # worker thread (when RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED is
+    # truthy) or inline on the event loop (default, legacy behaviour).
+    # FastMCP awaits the async tool directly, leaving dispatch entirely
+    # to our helper — keeping behaviour consistent with the static tools
+    # in main.py.
     def make_tool_fn(_model=model, _template_path=resolved, _name=name):
-        def tool_impl(data: _model) -> str:  # type: ignore
+        def _sync_impl(data):
             try:
                 # Load the template document
                 doc = DocxDocument(_template_path)
@@ -523,6 +535,9 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any]) -> None:
             except Exception as e:
                 logger.error(f"[dynamic-docx] Error generating document from {_name}: {e}", exc_info=True)
                 raise ToolError(f"Error generating document from template {_name}: {e}")
+
+        async def tool_impl(data: _model) -> str:  # type: ignore
+            return await run_blocking(_sync_impl, data)
 
         tool_impl.__annotations__['data'] = _model  # type: ignore[index]
         tool_impl.__annotations__['return'] = str  # type: ignore[index]

--- a/docx_tools/helpers.py
+++ b/docx_tools/helpers.py
@@ -333,6 +333,44 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
             else:
                 break
 
+    # ---------------------------------------------------------------------
+    # Forward-progress guarantee
+    # ---------------------------------------------------------------------
+    # If we never advanced ``i``, the caller's outer dispatch loop will
+    # re-detect the same line as a list and call us again with the same
+    # arguments — an infinite loop.
+    #
+    # This happens when the caller (``markdown_to_word``) made its match
+    # decision on the FULLY STRIPPED line, but this function's level
+    # check uses the ORIGINAL line's indent. They can disagree: a line
+    # like ``"   1. item"`` strips to ``"1. item"`` (matches
+    # ``ORDERED_LIST_PATTERN``) but its indent of 3 makes
+    # ``current_level=1``, which mismatches the requested ``level=0``,
+    # so the loop breaks before consuming anything.
+    #
+    # To guarantee both forward progress AND preserve the user's
+    # content, render the offending line as a plain paragraph (same
+    # treatment ``markdown_to_word`` gives any unrecognised line) and
+    # advance ``i`` past it. This branch is a no-op on the happy path
+    # (where ``i`` was advanced inside the loop) and on every recursive
+    # call (where ``current_level == level`` is established by the
+    # caller before recursing, so the inner first iteration cannot
+    # trigger this fallback).
+    if i == start_idx:
+        original_line = lines[start_idx]
+        stripped_line = original_line.strip()
+        logger.warning(
+            "process_list_items: no progress at line %d (%r) for level=%d; "
+            "rendering as a plain paragraph to guarantee forward progress",
+            start_idx, stripped_line, level,
+        )
+        paragraph = doc.add_paragraph()
+        parse_inline_formatting(stripped_line, paragraph)
+        if return_elements:
+            elements.append(paragraph._p)
+            doc._body._body.remove(paragraph._p)
+        i = start_idx + 1
+
     return i, elements
 
 

--- a/docx_tools/helpers.py
+++ b/docx_tools/helpers.py
@@ -106,6 +106,14 @@ _INLINE_FORMAT_RE = re.compile(
     r'|\[[^\]]*\]\([^)]*\))'             # [link](url)
 )
 
+# Pre-compiled inline patterns used inside the formatting hot path. The
+# previous implementations called ``re.match(...)`` / ``re.sub(...)`` with
+# string literals on every invocation — each call paying the regex-cache
+# lookup. Hoisting the compilation to module scope keeps the loops tight
+# without altering match behaviour.
+_LINK_RE = re.compile(r'\[(.*?)]\((.*?)\)')        # [link text](url)
+_ESCAPE_RE = re.compile(r'\\(.)')                   # backslash-escaped character
+
 
 def _parse_formatting_segment(text, paragraph, bold=False, italic=False, escape_ctx=None):
     """Parse a single text segment for inline markdown formatting."""
@@ -131,7 +139,7 @@ def _parse_formatting_segment(text, paragraph, bold=False, italic=False, escape_
             run.font.name = 'Courier New'
             _apply_formatting(run, bold, italic)
         elif part.startswith('[') and '](' in part and part.endswith(')'):
-            link_match = re.match(r'\[(.*?)]\((.*?)\)', part)
+            link_match = _LINK_RE.match(part)
             if link_match:
                 link_text = _restore_escapes(link_match.group(1), escape_ctx)
                 link_url = _restore_escapes(link_match.group(2), escape_ctx)
@@ -154,7 +162,7 @@ def _handle_escapes(text, escape_ctx):
         escape_ctx["counter"] += 1
         return placeholder
 
-    return re.sub(r'\\(.)', _replace, text)
+    return _ESCAPE_RE.sub(_replace, text)
 
 
 def _restore_escapes(text, escape_ctx):
@@ -258,20 +266,34 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
     elements = [] if return_elements else None
     i = start_idx
 
-    while i < len(lines):
-        line = lines[i].strip()
+    # Cache len() once — `lines` is never mutated inside this function or
+    # its recursive call, so the bound is stable. Avoids a function call
+    # per loop iteration across two nested loops.
+    n = len(lines)
 
+    # Choose the capture-variant regex once per call rather than re-checking
+    # `is_ordered` on every iteration. Both patterns capture the list item
+    # text in group(1).
+    list_capture_pattern = (
+        ORDERED_LIST_CAPTURE_PATTERN if is_ordered else UNORDERED_LIST_CAPTURE_PATTERN
+    )
+
+    while i < n:
+        # Compute the leading-whitespace length and the stripped line in a
+        # single lstrip() pass. The original code did `lines[i].strip()`
+        # plus an independent `lines[i].lstrip()` — walking the leading
+        # whitespace twice. ``stripped_left.rstrip()`` is equivalent to
+        # ``lines[i].strip()`` (both lstrip and rstrip applied).
         original_line = lines[i]
-        indent = len(original_line) - len(original_line.lstrip())
+        stripped_left = original_line.lstrip()
+        indent = len(original_line) - len(stripped_left)
+        line = stripped_left.rstrip()
         current_level = indent // 3
 
         if current_level != level:
             break
 
-        if is_ordered:
-            list_match = re.match(r'^\d+\.\s+(.+)', line)
-        else:
-            list_match = re.match(r'^[-*+]\s+(.+)', line)
+        list_match = list_capture_pattern.match(line)
 
         if not list_match:
             break
@@ -286,19 +308,20 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
         i += 1
 
         # Look ahead for nested items
-        while i < len(lines):
-            next_line = lines[i].strip()
+        while i < n:
+            next_original = lines[i]
+            next_stripped_left = next_original.lstrip()
+            next_line = next_stripped_left.rstrip()
             if not next_line:
                 i += 1
                 continue
 
-            next_original = lines[i]
-            next_indent = len(next_original) - len(next_original.lstrip())
+            next_indent = len(next_original) - len(next_stripped_left)
             next_level = next_indent // 3
 
             if next_level > level:
-                is_nested_ordered = bool(re.match(r'^\d+\.\s+', next_line))
-                is_nested_unordered = bool(re.match(r'^[-*+]\s+', next_line))
+                is_nested_ordered = bool(ORDERED_LIST_PATTERN.match(next_line))
+                is_nested_unordered = bool(UNORDERED_LIST_PATTERN.match(next_line))
                 if is_nested_ordered or is_nested_unordered:
                     i, nested = process_list_items(
                         lines, i, doc, is_nested_ordered, next_level, return_elements
@@ -319,6 +342,12 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
 
 ORDERED_LIST_PATTERN = re.compile(r'^\d+\.\s+')
 UNORDERED_LIST_PATTERN = re.compile(r'^[-*+]\s+')
+# Capture variants used by process_list_items() to extract the item text.
+# Kept separate from the block-detection patterns above (which are used by
+# contains_block_markdown / _BLOCK_PATTERNS for fast "is this a list line?"
+# checks and have no capture group).
+ORDERED_LIST_CAPTURE_PATTERN = re.compile(r'^\d+\.\s+(.+)')
+UNORDERED_LIST_CAPTURE_PATTERN = re.compile(r'^[-*+]\s+(.+)')
 HEADING_PATTERN = re.compile(r'^(#{1,6})\s+(.+)$')
 PAGE_BREAK_PATTERN = re.compile(r'^-{3,}\s*$')
 HORIZONTAL_LINE_PATTERN = re.compile(r'^\*{3,}\s*$')

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -20,6 +20,7 @@ from pydantic import Field, create_model
 from fastmcp import FastMCP
 from upload_tools import upload_file
 from template_utils import find_email_template
+from async_runner import run_blocking
 from fastmcp.exceptions import ToolError
 
 
@@ -116,8 +117,13 @@ def register_email_template_tools_from_yaml(mcp: FastMCP, yaml_path: Path) -> No
 
             renderer = pystache.Renderer(file_encoding="utf-8")
 
+            # Tool body is synchronous and blocking (mustache rendering,
+            # MIME construction, synchronous upload). Wrap it in an
+            # `async def` that dispatches through `run_blocking()` so
+            # behaviour follows the RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED
+            # flag uniformly with the rest of the tools.
             def make_tool_fn(_model=model, _html=html_source, _renderer=renderer, _name=name):
-                def tool_impl(data):
+                def _sync_impl(data):
                     try:
                         payload = data.model_dump()
                         safe_payload = {k: ("" if v is None else v) for k, v in payload.items()}
@@ -165,6 +171,9 @@ def register_email_template_tools_from_yaml(mcp: FastMCP, yaml_path: Path) -> No
                     except Exception as e:
                         logger.error(f"[dynamic-email] Unexpected error in tool '{_name}': {e}", exc_info=True)
                         raise ToolError(f"Error generating email from template '{_name}': {e}")
+
+                async def tool_impl(data):
+                    return await run_blocking(_sync_impl, data)
 
                 tool_impl.__annotations__['data'] = _model  # type: ignore[index]
                 tool_impl.__annotations__['return'] = str  # type: ignore[index]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
-import asyncio
-import functools
-from typing import Annotated, Callable, List, Dict, Optional, Literal, TypeVar
+from typing import Annotated, List, Dict, Optional, Literal
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -15,6 +13,7 @@ from pathlib import Path
 from config import get_config
 from xml_tools import create_xml_file
 from middleware import ApiKeyAuthMiddleware
+from async_runner import run_blocking
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
@@ -22,68 +21,8 @@ import logging
 mcp = FastMCP("MCP Office Documents")
 
 
-# ---------------------------------------------------------------------------
-# Async-safe wrapper for blocking document-generation calls
-# ---------------------------------------------------------------------------
-# Every Office-document generator in this project (markdown_to_word,
-# markdown_to_excel, create_presentation, create_eml, create_xml_file) is a
-# synchronous, blocking function. They perform:
-#
-#   * file I/O (opening .docx / .pptx templates, which are zip archives)
-#   * CPU-bound markdown parsing
-#   * synchronous network I/O (requests.get for image downloads, boto3
-#     S3 uploads)
-#
-# FastMCP runs on top of an asyncio event loop (uvicorn / Starlette).
-# Calling a blocking function directly from an `async def` tool handler
-# freezes the loop for the full duration of the call — no other request
-# can be served while the loop is blocked, including the Kubernetes
-# liveness / readiness probes at /healthl, /healthr, /healths. Repeated
-# probe timeouts cause kubelet to SIGTERM the pod, which is the failure
-# mode we observed in EKS:
-#
-#     ERROR: ASGI callable returned without completing response.
-#     ERROR: Cancel 0 running task(s), timeout graceful shutdown exceeded
-#
-# (The "0 running tasks" line is the giveaway: there were no async tasks
-# because the work was running synchronously on the event loop itself.)
-#
-# To keep the loop responsive, all blocking work is dispatched to the
-# default asyncio thread pool via `asyncio.to_thread`. The wrapper
-# preserves the original function's call signature exactly — no behavioral
-# change to any tool's logic.
-# ---------------------------------------------------------------------------
-
-T = TypeVar("T")
-
-
-async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
-    """Run a synchronous callable on a worker thread.
-
-    Use this from any `async def` MCP tool handler that calls into a
-    blocking document-generation function. The synchronous function runs
-    on asyncio's default thread pool while the event loop stays free to
-    serve health probes, pings, and concurrent requests.
-
-    Args:
-        func: The blocking function to execute.
-        *args: Positional arguments forwarded to ``func``.
-        **kwargs: Keyword arguments forwarded to ``func``.
-
-    Returns:
-        Whatever ``func`` returns, awaited from the thread.
-
-    Raises:
-        Any exception ``func`` raises is re-raised in the calling
-        coroutine after being marshalled back from the worker thread.
-    """
-    # functools.partial binds kwargs cleanly; asyncio.to_thread accepts
-    # *args/**kwargs directly, but going through partial keeps the call
-    # site readable and makes the closure easy to log if needed.
-    bound = functools.partial(func, *args, **kwargs)
-    return await asyncio.to_thread(bound)
-
-# Initialize config and logging
+# Initialize config and logging (must come before run_blocking, which reads
+# config.run_blocking_by_asyncio_thread_enabled at call time)
 config = get_config()
 logger = logging.getLogger(__name__)
 
@@ -93,6 +32,30 @@ if config.api_key:
     logger.info("[auth] API key authentication enabled")
 else:
     logger.info("[auth] No API_KEY set – authentication disabled")
+
+
+# ---------------------------------------------------------------------------
+# Async-safe wrapper for blocking document-generation calls
+# ---------------------------------------------------------------------------
+# `run_blocking()` is imported from `async_runner` (above). It lives in its
+# own module so dynamically-registered tool modules (dynamic_docx_tools,
+# dynamic_email_tools) can import it without creating a circular dependency
+# back through this `main` module. See `async_runner.py` for the full
+# rationale, the EKS failure mode it addresses, and the meaning of the
+# `RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED` environment variable.
+#
+# All MCP tool handlers — both the static ones declared below and the
+# dynamic ones registered from YAML — uniformly write
+# `await run_blocking(sync_func, ...)`. The helper decides at call time
+# whether to dispatch the work to a worker thread (when enabled) or to
+# run it inline on the event loop (when disabled, legacy behaviour).
+# ---------------------------------------------------------------------------
+
+logger.info(
+    "[run_blocking] thread-offload %s (RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=%s)",
+    "ENABLED" if config.run_blocking_by_asyncio_thread_enabled else "DISABLED",
+    str(config.run_blocking_by_asyncio_thread_enabled).lower(),
+)
 
 
 # ---------------------------------------------------------------------------

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
+import asyncio
+import functools
+from typing import Annotated, Callable, List, Dict, Optional, Literal, TypeVar
+
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
-from typing import Annotated, List, Dict, Optional, Literal
 from xlsx_tools import markdown_to_excel
 from docx_tools import markdown_to_word
 from docx_tools.dynamic_docx_tools import register_docx_template_tools_from_yaml
@@ -17,6 +20,68 @@ from starlette.responses import PlainTextResponse
 
 import logging
 mcp = FastMCP("MCP Office Documents")
+
+
+# ---------------------------------------------------------------------------
+# Async-safe wrapper for blocking document-generation calls
+# ---------------------------------------------------------------------------
+# Every Office-document generator in this project (markdown_to_word,
+# markdown_to_excel, create_presentation, create_eml, create_xml_file) is a
+# synchronous, blocking function. They perform:
+#
+#   * file I/O (opening .docx / .pptx templates, which are zip archives)
+#   * CPU-bound markdown parsing
+#   * synchronous network I/O (requests.get for image downloads, boto3
+#     S3 uploads)
+#
+# FastMCP runs on top of an asyncio event loop (uvicorn / Starlette).
+# Calling a blocking function directly from an `async def` tool handler
+# freezes the loop for the full duration of the call — no other request
+# can be served while the loop is blocked, including the Kubernetes
+# liveness / readiness probes at /healthl, /healthr, /healths. Repeated
+# probe timeouts cause kubelet to SIGTERM the pod, which is the failure
+# mode we observed in EKS:
+#
+#     ERROR: ASGI callable returned without completing response.
+#     ERROR: Cancel 0 running task(s), timeout graceful shutdown exceeded
+#
+# (The "0 running tasks" line is the giveaway: there were no async tasks
+# because the work was running synchronously on the event loop itself.)
+#
+# To keep the loop responsive, all blocking work is dispatched to the
+# default asyncio thread pool via `asyncio.to_thread`. The wrapper
+# preserves the original function's call signature exactly — no behavioral
+# change to any tool's logic.
+# ---------------------------------------------------------------------------
+
+T = TypeVar("T")
+
+
+async def run_blocking(func: Callable[..., T], /, *args, **kwargs) -> T:
+    """Run a synchronous callable on a worker thread.
+
+    Use this from any `async def` MCP tool handler that calls into a
+    blocking document-generation function. The synchronous function runs
+    on asyncio's default thread pool while the event loop stays free to
+    serve health probes, pings, and concurrent requests.
+
+    Args:
+        func: The blocking function to execute.
+        *args: Positional arguments forwarded to ``func``.
+        **kwargs: Keyword arguments forwarded to ``func``.
+
+    Returns:
+        Whatever ``func`` returns, awaited from the thread.
+
+    Raises:
+        Any exception ``func`` raises is re-raised in the calling
+        coroutine after being marshalled back from the worker thread.
+    """
+    # functools.partial binds kwargs cleanly; asyncio.to_thread accepts
+    # *args/**kwargs directly, but going through partial keeps the call
+    # site readable and makes the closure easy to log if needed.
+    bound = functools.partial(func, *args, **kwargs)
+    return await asyncio.to_thread(bound)
 
 # Initialize config and logging
 config = get_config()
@@ -45,28 +110,28 @@ else:
 #   the application, catching "alive port, dead process" failures.
 #
 # Probes (see k8s deployment manifest):
-#   /healths — startupProbe   (pod has started)
-#   /healthr — readinessProbe (pod is ready to receive traffic)
-#   /healthl — livenessProbe  (pod is alive; restart on failure)
+#   /healthz — startupProbe   (pod has started)
+#   /readyz — readinessProbe (pod is ready to receive traffic)
+#   /livez — livenessProbe  (pod is alive; restart on failure)
 #
 # Each endpoint returns 200 OK with a short plain-text body. If the server
 # event loop is wedged, the request will time out and kubelet will mark
 # the probe as failed.
 # ---------------------------------------------------------------------------
 
-@mcp.custom_route("/healths", methods=["GET"])
+@mcp.custom_route("/healthz", methods=["GET"])
 async def health_startup(request: Request) -> PlainTextResponse:
     """Startup probe — returns 200 OK once the HTTP server is accepting requests."""
     return PlainTextResponse("ok", status_code=200)
 
 
-@mcp.custom_route("/healthr", methods=["GET"])
+@mcp.custom_route("/readyz", methods=["GET"])
 async def health_ready(request: Request) -> PlainTextResponse:
     """Readiness probe — returns 200 OK when the server can serve traffic."""
     return PlainTextResponse("ready", status_code=200)
 
 
-@mcp.custom_route("/healthl", methods=["GET"])
+@mcp.custom_route("/livez", methods=["GET"])
 async def health_live(request: Request) -> PlainTextResponse:
     """Liveness probe — returns 200 OK while the event loop is responsive."""
     return PlainTextResponse("alive", status_code=200)
@@ -150,7 +215,7 @@ async def create_excel_document(
     logger.info("Converting markdown to Excel document")
 
     try:
-        result = markdown_to_excel(markdown_content)
+        result = await run_blocking(markdown_to_excel, markdown_content)
         logger.info("Excel document uploaded successfully")
         return result
     except Exception as e:
@@ -213,7 +278,8 @@ async def create_word_document(
     logger.info("Converting markdown to Word document")
 
     try:
-        result = markdown_to_word(
+        result = await run_blocking(
+            markdown_to_word,
             markdown_content,
             title=title,
             author=author,
@@ -259,7 +325,7 @@ All slides support optional 'speaker_notes': str field."""
     logger.info(f"Creating PowerPoint presentation with {len(slides)} slides in {format} format")
 
     try:
-        result = create_presentation(slides, format)
+        result = await run_blocking(create_presentation, slides, format)
         logger.info(f"PowerPoint presentation created: {result}")
         return result
     except Exception as e:
@@ -288,14 +354,15 @@ async def create_email_draft(
     logger.info(f"Creating email draft with subject: {subject}")
 
     try:
-        result = create_eml(
+        result = await run_blocking(
+            create_eml,
             to=to,
             cc=cc,
             bcc=bcc,
             re=subject,
             content=content,
             priority=priority,
-            language=language
+            language=language,
         )
         logger.info(f"Email draft created: {result}")
         return result
@@ -320,7 +387,7 @@ async def create_xml_document(
     logger.info("Creating XML file")
 
     try:
-        result = create_xml_file(xml_content)
+        result = await run_blocking(create_xml_file, xml_content)
         logger.info(f"XML file created successfully.")
         return result
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from config import get_config
 from xml_tools import create_xml_file
 from middleware import ApiKeyAuthMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
 
 import logging
 mcp = FastMCP("MCP Office Documents")
@@ -26,6 +28,48 @@ if config.api_key:
     logger.info("[auth] API key authentication enabled")
 else:
     logger.info("[auth] No API_KEY set – authentication disabled")
+
+
+# ---------------------------------------------------------------------------
+# Kubernetes health-check endpoints
+# ---------------------------------------------------------------------------
+# These plain HTTP routes are registered at the Starlette layer (via
+# FastMCP's @custom_route) and therefore sit OUTSIDE the MCP protocol
+# middleware stack — they intentionally bypass the API-key auth middleware
+# so kubelet can poll them without credentials.
+#
+# Why HTTP (not TCP) probes?
+#   A TCP probe only verifies the socket accepts a connection. If the
+#   Python process is wedged but the listener is still bound, the kubelet
+#   never restarts the pod. An HTTP probe forces an actual response from
+#   the application, catching "alive port, dead process" failures.
+#
+# Probes (see k8s deployment manifest):
+#   /healths — startupProbe   (pod has started)
+#   /healthr — readinessProbe (pod is ready to receive traffic)
+#   /healthl — livenessProbe  (pod is alive; restart on failure)
+#
+# Each endpoint returns 200 OK with a short plain-text body. If the server
+# event loop is wedged, the request will time out and kubelet will mark
+# the probe as failed.
+# ---------------------------------------------------------------------------
+
+@mcp.custom_route("/healths", methods=["GET"])
+async def health_startup(request: Request) -> PlainTextResponse:
+    """Startup probe — returns 200 OK once the HTTP server is accepting requests."""
+    return PlainTextResponse("ok", status_code=200)
+
+
+@mcp.custom_route("/healthr", methods=["GET"])
+async def health_ready(request: Request) -> PlainTextResponse:
+    """Readiness probe — returns 200 OK when the server can serve traffic."""
+    return PlainTextResponse("ready", status_code=200)
+
+
+@mcp.custom_route("/healthl", methods=["GET"])
+async def health_live(request: Request) -> PlainTextResponse:
+    """Liveness probe — returns 200 OK while the event loop is responsive."""
+    return PlainTextResponse("alive", status_code=200)
 
 # Look for dynamic email templates in production and local locations.
 # Production (container): /app/config/email_templates.yaml

--- a/tests/test_docx_list_infinite_loop_regression.py
+++ b/tests/test_docx_list_infinite_loop_regression.py
@@ -1,0 +1,785 @@
+"""Regression tests for the ``markdown_to_word`` infinite-loop hang.
+
+Background
+----------
+The bug was observed in EKS production. A py-spy dump showed two
+``run_blocking_*`` worker threads pinned at 100 % CPU for 6+ hours each,
+both spinning at:
+
+    markdown_to_word (docx_tools/base_docx_tool.py:170)
+        process_list_items (docx_tools/helpers.py:264)
+
+Root cause
+----------
+When a markdown line has **leading whitespace** AND matches a list
+pattern on its stripped form (e.g. ``"   1. item"`` strips to
+``"1. item"``), the caller in ``markdown_to_word`` dispatches it::
+
+    elif ORDERED_LIST_PATTERN.match(line):           # matches '1. item'
+        i, _ = process_list_items(lines, i, doc, True, 0)
+
+…but ``process_list_items`` inspects the **original** line's indent (3
+characters → ``current_level = 1``) and breaks immediately on
+``current_level != level (0)``, returning ``start_idx`` unchanged. The
+caller's outer ``while`` then re-detects the same line, calls again,
+gets the same answer — and the loop never advances.
+
+Test mechanism
+--------------
+``markdown_to_word`` is run in a daemon thread with a wall-clock
+``join`` timeout. If the call doesn't return inside the timeout the
+test fails with an explicit message. The orphan thread keeps spinning
+until the pytest process exits — keep the markdown inputs *small* so
+the orphan does not steal too many GIL slots from subsequent tests in
+the same pytest session.
+
+Today (bug present) these tests **FAIL** with a clear timeout message.
+Once the forward-progress guard is added to ``process_list_items`` they
+**PASS** in well under a second.
+
+Debugging tip
+-------------
+To inspect the live hang interactively, run a single test verbosely::
+
+    pytest -xvs tests/test_docx_list_infinite_loop_regression.py::test_top_level_ordered_list_with_leading_whitespace_does_not_hang
+
+Then, during the 5-second window before the test fails, capture a
+py-spy dump in another shell::
+
+    py-spy dump --pid $(pgrep -f pytest)
+
+The dump should mirror the production stack trace (``process_list_items``
+called from ``markdown_to_word`` with the line index pinned).
+"""
+
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from docx import Document  # noqa: E402
+
+from docx_tools.base_docx_tool import markdown_to_word  # noqa: E402
+from docx_tools.helpers import process_list_items  # noqa: E402
+
+
+# Generous wall-clock budget. Real markdown_to_word on these tiny inputs
+# completes in well under 100 ms; 5 s is the "definitely hung" threshold.
+_TIMEOUT_SECONDS = 5.0
+
+
+def _run_in_thread(markdown_text, timeout=_TIMEOUT_SECONDS):
+    """Invoke ``markdown_to_word`` in a daemon thread, bounded by wall-clock.
+
+    Args:
+        markdown_text: Markdown content fed to ``markdown_to_word``.
+        timeout: Max seconds to wait for the call to return.
+
+    Returns:
+        Tuple ``(completed, result, error)``:
+          * ``completed`` (bool): True if the call returned within ``timeout``.
+          * ``result``: whatever ``markdown_to_word`` returned, or ``None``.
+          * ``error``: the exception raised by the call, if any.
+
+    The thread is created with ``daemon=True`` so it does not block the
+    pytest process from exiting. Python cannot kill a thread that has
+    not finished — if the bug is present the thread will keep running
+    in the background until the test session ends. Test inputs are kept
+    minimal to limit that cost.
+    """
+    holder = {"result": None, "error": None}
+
+    def target():
+        try:
+            holder["result"] = markdown_to_word(markdown_text)
+        except Exception as exc:  # noqa: BLE001 — re-raised below
+            holder["error"] = exc
+
+    t = threading.Thread(
+        target=target,
+        daemon=True,
+        name="markdown-to-word-regression",
+    )
+    t.start()
+    t.join(timeout=timeout)
+    return (not t.is_alive(), holder["result"], holder["error"])
+
+
+def test_top_level_ordered_list_with_leading_whitespace_does_not_hang():
+    """REGRESSION: ``'   1. item'`` at the top level previously hung the worker.
+
+    Reproduces the exact stack observed in the EKS py-spy dump.
+
+    Sequence the parser walks (today, buggy):
+
+      1. ``"Intro paragraph before the list."`` — falls into the
+         ``else:`` paragraph branch, advances ``i``.
+      2. Empty line — handled by the empty-line counter, advances ``i``.
+      3. ``"   1. First item..."`` — caller strips it to ``"1. First
+         item..."``, matches ``ORDERED_LIST_PATTERN``, calls
+         ``process_list_items(..., level=0)``. Inside, the indent of
+         the original line gives ``current_level=1``, which does not
+         equal ``level=0``, so the function breaks and returns
+         ``start_idx`` unchanged. The caller then loops back to step 3
+         forever.
+    """
+    md = (
+        "Intro paragraph before the list.\n"
+        "\n"
+        "   1. First item with 3-space indent\n"
+        "   2. Second item with 3-space indent\n"
+        "\n"
+        "Final paragraph after the list.\n"
+    )
+
+    completed, result, error = _run_in_thread(md)
+
+    assert completed, (
+        f"markdown_to_word did not complete within {_TIMEOUT_SECONDS:.0f}s "
+        f"on input with a top-level ORDERED list that has leading "
+        f"whitespace. This is the infinite-loop bug observed in EKS "
+        f"production (py-spy dump showed two worker threads pinned in "
+        f"markdown_to_word -> process_list_items)."
+    )
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+def test_top_level_unordered_list_with_leading_whitespace_does_not_hang():
+    """Same bug as the ordered-list case, with bullets instead of numbers.
+
+    ``UNORDERED_LIST_PATTERN`` matches ``"- bullet"`` on the stripped
+    line just like the ordered variant, so the same dispatch path is
+    exercised and the same infinite loop occurs in
+    ``process_list_items``.
+    """
+    md = (
+        "Some intro paragraph.\n"
+        "\n"
+        "   - first bullet with 3-space indent\n"
+        "   - second bullet with 3-space indent\n"
+        "\n"
+        "Some outro paragraph.\n"
+    )
+
+    completed, result, error = _run_in_thread(md)
+
+    assert completed, (
+        f"markdown_to_word did not complete within {_TIMEOUT_SECONDS:.0f}s "
+        f"on input with a top-level UNORDERED list that has leading "
+        f"whitespace. Same root cause as the ordered-list variant — see "
+        f"the module docstring for the full trace."
+    )
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Helper-level unit tests — exercise process_list_items in isolation.
+# ---------------------------------------------------------------------------
+# These tests do not invoke ``markdown_to_word`` (and therefore do not need
+# a threading-based timeout). They call ``process_list_items`` directly and
+# assert the *forward-progress* property: regardless of input, the returned
+# index must be strictly greater than ``start_idx`` so the caller's outer
+# loop is guaranteed to advance.
+#
+# The bug is that today, when the original line's indent does not match
+# the requested ``level`` (which happens when the caller dispatched based
+# on the stripped form), ``process_list_items`` breaks on the very first
+# iteration and returns ``start_idx`` unchanged. The fix must restore the
+# forward-progress invariant.
+# ---------------------------------------------------------------------------
+
+
+def _new_blank_doc():
+    """Create a minimal ``docx.Document`` for tests.
+
+    Returns a Document with no template so we don't depend on the local
+    ``custom_templates/*.docx`` having particular styles. The bug path
+    in ``process_list_items`` breaks BEFORE any ``add_paragraph(style=...)``
+    call, so a blank document is sufficient to reproduce the failure.
+    The forward-progress fallback (once applied) calls ``add_paragraph()``
+    with no style, which is always valid on a blank Document.
+    """
+    return Document()
+
+
+def test_process_list_items_advances_on_ordered_line_with_leading_whitespace():
+    """REGRESSION (unit-level): process_list_items must return ``i > start_idx``.
+
+    Today this assertion fails because the function returns
+    ``start_idx`` unchanged when the original line's indent does not
+    match the requested ``level``. The caller (``markdown_to_word``)
+    re-dispatches and spins forever — see the threaded tests above.
+
+    Use a debugger here to step through the exact code path:
+
+        breakpoint()  # or set in helpers.py:281 (top of the while loop)
+        ...
+    """
+    lines = ["   1. First item with 3-space indent"]
+    start_idx = 0
+    doc = _new_blank_doc()
+
+    new_idx, _elements = process_list_items(
+        lines, start_idx, doc, is_ordered=True, level=0
+    )
+
+    assert new_idx > start_idx, (
+        f"process_list_items returned new_idx={new_idx} (== start_idx). "
+        f"This violates the forward-progress invariant the caller relies "
+        f"on. With this input, markdown_to_word's outer dispatch loop "
+        f"would re-detect the same line as a list and spin forever."
+    )
+
+
+def test_process_list_items_advances_on_unordered_line_with_leading_whitespace():
+    """Same forward-progress assertion for the bullet-list variant."""
+    lines = ["   - bullet with 3-space indent"]
+    start_idx = 0
+    doc = _new_blank_doc()
+
+    new_idx, _elements = process_list_items(
+        lines, start_idx, doc, is_ordered=False, level=0
+    )
+
+    assert new_idx > start_idx, (
+        f"process_list_items returned new_idx={new_idx} (== start_idx) "
+        f"for an unordered list line with leading whitespace. Forward-"
+        f"progress invariant violated; see the ordered-list test for the "
+        f"full explanation."
+    )
+
+
+def test_process_list_items_advances_on_mid_document_offset():
+    """Forward progress must also hold when start_idx is mid-document.
+
+    The bug isn't index-dependent — it's about indent vs level mismatch
+    on the very first line the function inspects. We exercise that
+    independently of ``start_idx=0`` to make sure no off-by-one creeps
+    into the eventual fix.
+    """
+    lines = [
+        "Some earlier content.",
+        "",
+        "   1. Indented item starts here (start_idx=2)",
+    ]
+    start_idx = 2
+    doc = _new_blank_doc()
+
+    new_idx, _elements = process_list_items(
+        lines, start_idx, doc, is_ordered=True, level=0
+    )
+
+    assert new_idx > start_idx, (
+        f"process_list_items returned new_idx={new_idx} for start_idx={start_idx}; "
+        f"the function must always advance past the line it cannot process."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests — for comparison with the failing regression tests above.
+# ---------------------------------------------------------------------------
+# These exercise the code paths the buggy tests *should* end up on once the
+# fix is applied: properly-formed lists with no leading whitespace. They
+# verify that:
+#
+#   1. ``process_list_items`` consumes the list lines and emits paragraphs
+#      with the correct ``List Number`` / ``List Bullet`` styles (i.e. the
+#      ``paragraph = doc.add_paragraph(style=style)`` line at
+#      helpers.py:301 is actually executed and works).
+#   2. ``markdown_to_word`` runs end-to-end on a document containing both
+#      ordered and unordered lists, without hanging.
+#
+# These tests already pass today (the bug is dormant for well-formed input)
+# and must continue to pass after the forward-progress fix lands — they're
+# the "control group" for the regression suite.
+# ---------------------------------------------------------------------------
+
+
+def _new_doc_with_default_styles():
+    """Create a ``Document`` from the project's default template.
+
+    The default template (``default_templates/default_docx_template.docx``)
+    contains every paragraph style the parser uses — ``Heading 1``..``6``,
+    ``List Number``, ``List Bullet``, ``Quote``, ``Table Grid``, etc. We
+    use it directly so these tests don't depend on whatever template the
+    ``custom_templates/`` directory happens to contain locally.
+    """
+    default = project_root / "default_templates" / "default_docx_template.docx"
+    assert default.exists(), f"Default template missing at {default}"
+    return Document(str(default))
+
+
+@pytest.fixture
+def use_default_template(monkeypatch):
+    """Force ``markdown_to_word`` to load the default template.
+
+    The local ``custom_templates/custom_docx_template.docx`` (BU asset
+    bundle) lacks several styles the parser uses on the happy path
+    (``Heading 1``, ``List Number``, ``List Bullet``, ``Quote``). Rather
+    than mutate the filesystem we patch the ``load_templates`` symbol
+    that ``markdown_to_word`` looks up at call time, redirecting it to
+    the default template path. The fixture is scoped to a single test
+    and ``monkeypatch`` restores the original binding automatically.
+    """
+    default = project_root / "default_templates" / "default_docx_template.docx"
+    assert default.exists(), f"Default template missing at {default}"
+
+    import docx_tools.base_docx_tool as _base
+    monkeypatch.setattr(_base, "load_templates", lambda: str(default))
+    yield
+
+
+def test_process_list_items_creates_ordered_list_paragraphs():
+    """Happy path at the helper level for ordered (numbered) lists.
+
+    Verifies that:
+      * ``new_idx`` advances by the number of list lines consumed,
+      * the document gains paragraphs whose style name is ``List Number``,
+      * the paragraph text matches the list-item content (the part after
+        ``"N. "``, with inline formatting stripped of markers).
+
+    This is exactly what the ``doc.add_paragraph(style=style)`` line at
+    [docx_tools/helpers.py:301](docx_tools/helpers.py#L301) is supposed
+    to produce on the happy path.
+    """
+    lines = ["1. First item", "2. Second item", "3. Third item"]
+    doc = _new_doc_with_default_styles()
+    initial_paragraph_count = len(doc.paragraphs)
+
+    new_idx, _elements = process_list_items(
+        lines, 0, doc, is_ordered=True, level=0
+    )
+
+    assert new_idx == 3, (
+        f"Expected process_list_items to consume all 3 list lines "
+        f"(new_idx=3); got new_idx={new_idx}"
+    )
+
+    list_paragraphs = [
+        p for p in doc.paragraphs[initial_paragraph_count:]
+        if p.style.name == "List Number"
+    ]
+    assert len(list_paragraphs) == 3, (
+        f"Expected 3 'List Number'-styled paragraphs; got {len(list_paragraphs)}. "
+        f"All new paragraphs: "
+        f"{[(p.text, p.style.name) for p in doc.paragraphs[initial_paragraph_count:]]}"
+    )
+    assert list_paragraphs[0].text == "First item"
+    assert list_paragraphs[1].text == "Second item"
+    assert list_paragraphs[2].text == "Third item"
+
+
+def test_process_list_items_creates_unordered_list_paragraphs():
+    """Happy path at the helper level for unordered (bullet) lists.
+
+    Same shape as the ordered-list test above, but for the
+    ``List Bullet`` style branch.
+    """
+    lines = ["- alpha", "- beta", "- gamma"]
+    doc = _new_doc_with_default_styles()
+    initial_paragraph_count = len(doc.paragraphs)
+
+    new_idx, _elements = process_list_items(
+        lines, 0, doc, is_ordered=False, level=0
+    )
+
+    assert new_idx == 3
+    list_paragraphs = [
+        p for p in doc.paragraphs[initial_paragraph_count:]
+        if p.style.name == "List Bullet"
+    ]
+    assert len(list_paragraphs) == 3
+    assert [p.text for p in list_paragraphs] == ["alpha", "beta", "gamma"]
+
+
+def test_markdown_to_word_with_valid_lists_completes_promptly(use_default_template):
+    """End-to-end happy path: ``markdown_to_word`` with well-formed lists.
+
+    No leading whitespace, so the dispatch path stays on the normal
+    branch and ``process_list_items`` consumes every list line. The
+    call must return quickly with a non-None result (file path or URL
+    depending on the configured upload backend — LOCAL here).
+
+    Use this test alongside the threaded regression tests to confirm
+    that the *only* thing different about the buggy input is the
+    leading whitespace.
+    """
+    md = (
+        "Introductory paragraph before any lists.\n"
+        "\n"
+        "1. First ordered item\n"
+        "2. Second ordered item\n"
+        "3. Third ordered item\n"
+        "\n"
+        "- First bullet\n"
+        "- Second bullet\n"
+        "- Third bullet\n"
+        "\n"
+        "Closing paragraph after the lists.\n"
+    )
+
+    completed, result, error = _run_in_thread(md, timeout=10)
+
+    assert completed, (
+        "markdown_to_word did not complete on well-formed input — if this "
+        "fails, the bug has spread beyond leading-whitespace lines"
+    )
+    if error is not None:
+        raise error
+    assert result is not None
+    assert isinstance(result, str) and result, (
+        f"Expected a non-empty result string; got {result!r}"
+    )
+
+
+def test_process_list_items_handles_nested_unordered_list():
+    """Happy path at the helper level for **nested** bullet lists.
+
+    Exercises the recursive call inside ``process_list_items`` (the
+    "Look ahead for nested items" inner loop). Nested levels are
+    detected via 3-space indent increments — ``level=0`` for the top
+    list, ``level=1`` for sub-items.
+
+    The input:
+
+        - Main item 1
+           - Sub item 1.1     ← 3-space indent → level 1
+           - Sub item 1.2     ← still level 1
+        - Main item 2          ← back to level 0
+           - Sub item 2.1     ← level 1 again
+
+    Expected document state after the call:
+
+        ┌────────────────┬──────────────────┐
+        │ Paragraph text │ Style            │
+        ├────────────────┼──────────────────┤
+        │ Main item 1    │ List Bullet      │
+        │ Sub item 1.1   │ List Bullet 2    │
+        │ Sub item 1.2   │ List Bullet 2    │
+        │ Main item 2    │ List Bullet      │
+        │ Sub item 2.1   │ List Bullet 2    │
+        └────────────────┴──────────────────┘
+
+    Useful for stepping a debugger through the recursive descent:
+    drop a ``breakpoint()`` just before the recursive call site in
+    ``process_list_items`` (the ``i, nested = process_list_items(...)``
+    line in the inner lookahead loop) and watch ``level`` increase
+    from 0 → 1 then return.
+    """
+    lines = [
+        "- Main item 1",
+        "   - Sub item 1.1",
+        "   - Sub item 1.2",
+        "- Main item 2",
+        "   - Sub item 2.1",
+    ]
+    doc = _new_doc_with_default_styles()
+    initial_paragraph_count = len(doc.paragraphs)
+
+    markdown_cnt = """   - Main item 1
+     - Sub item 1.1
+     - Sub item 1.2
+- Main item 2
+   - Sub item 2.1
+"""
+    # markdown_to_word(markdown_cnt, file_name="MZA-markdown-regression.docx")
+
+    new_idx, _elements = process_list_items(
+        lines, 0, doc, is_ordered=False, level=0
+    )
+
+    # All 5 lines consumed (no trailing empty line in this slice).
+    assert new_idx == len(lines), (
+        f"Expected to consume all {len(lines)} lines; got new_idx={new_idx}"
+    )
+
+    new_paragraphs = doc.paragraphs[initial_paragraph_count:]
+    text_and_style = [(p.text, p.style.name) for p in new_paragraphs]
+
+    expected = [
+        ("Main item 1",  "List Bullet"),
+        ("Sub item 1.1", "List Bullet 2"),
+        ("Sub item 1.2", "List Bullet 2"),
+        ("Main item 2",  "List Bullet"),
+        ("Sub item 2.1", "List Bullet 2"),
+    ]
+    assert text_and_style == expected, (
+        f"Nested list paragraphs do not match expected output.\n"
+        f"  expected: {expected}\n"
+        f"  got:      {text_and_style}"
+    )
+
+
+def test_markdown_to_word_with_nested_lists_completes_promptly(use_default_template):
+    """End-to-end happy path for nested lists, mirroring the markdown in
+    the user-facing tools.
+
+    Same content as ``test_process_list_items_handles_nested_unordered_list``
+    but driven through the public ``markdown_to_word`` entry point. This
+    exercises the full pipeline: outer ``markdown_to_word`` loop →
+    ``UNORDERED_LIST_PATTERN`` match → ``process_list_items(... level=0)``
+    → recursive call at level 1 → return → continue parsing.
+    """
+    md = (
+        "- Main item 1\n"
+        "   - Sub item 1.1\n"
+        "   - Sub item 1.2\n"
+        "- Main item 2\n"
+        "   - Sub item 2.1\n"
+    )
+
+    completed, result, error = _run_in_thread(md, timeout=10)
+
+    assert completed, (
+        "markdown_to_word did not complete on a well-formed nested bullet "
+        "list — recursive descent in process_list_items may be broken"
+    )
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Forward-progress verification for additional edge cases.
+# ---------------------------------------------------------------------------
+# These tests cover inputs that exercise the various entry conditions of
+# ``process_list_items`` to make sure the forward-progress invariant
+# (``returned_idx > start_idx``) holds for every shape of pathological
+# input we can think of. They also confirm the recursive descent and the
+# ``return_elements`` mode still work after the fix is applied.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "indent_spaces",
+    [3, 4, 6, 9, 12],
+    ids=lambda n: f"indent={n}",
+)
+def test_process_list_items_advances_on_various_indent_widths(indent_spaces):
+    """Forward progress must hold for any leading-whitespace width, not
+    just the canonical 3-space indent."""
+    line = (" " * indent_spaces) + "1. Indented item"
+    doc = _new_blank_doc()
+    new_idx, _ = process_list_items([line], 0, doc, is_ordered=True, level=0)
+    assert new_idx > 0, (
+        f"process_list_items did not advance for indent={indent_spaces} spaces"
+    )
+
+
+def test_process_list_items_advances_on_tab_indent():
+    """Tabs in the leading whitespace must not cause a hang either.
+
+    A tab character contributes 1 to the indent count (Python's
+    ``str.lstrip`` strips all whitespace including tabs), so a single
+    leading tab yields ``current_level = 0`` and the line would
+    actually pass the indent check. Multiple tabs (or tab+space)
+    produce a non-zero indent that mismatches level=0 and previously
+    triggered the hang. Either way, the function must advance.
+    """
+    lines = ["\t\t1. Tab-indented item"]
+    doc = _new_blank_doc()
+    new_idx, _ = process_list_items(lines, 0, doc, is_ordered=True, level=0)
+    assert new_idx > 0
+
+
+def test_process_list_items_advances_on_mixed_valid_and_invalid_input():
+    """A valid list followed by an indented list line is handled by the
+    existing nested-list recursion path, not the forward-progress guard.
+
+    Trace for these three lines:
+      i=0  "1. Valid item one"        consumed at level 0
+      i=1  "2. Valid item two"        consumed at level 0; inner lookahead
+                                       sees line i=2 with indent=3 (next_level=1
+                                       > level=0) and recurses
+      i=2  "   3. Indented..."        consumed at level 1 by the recursive
+                                       call (current_level=1 == level=1)
+
+    All three lines are consumed (``new_idx == 3``). The
+    forward-progress guard is a no-op here. The infinite-loop bug only
+    triggered when the indented line appeared at the TOP level (no
+    valid list item directly above it to anchor recursion). Those
+    cases are covered by the earlier tests.
+    """
+    lines = [
+        "1. Valid item one",
+        "2. Valid item two",
+        "   3. Indented after valid list (treated as nested)",
+    ]
+    doc = _new_doc_with_default_styles()
+    new_idx, _ = process_list_items(lines, 0, doc, is_ordered=True, level=0)
+
+    assert new_idx == 3, (
+        f"All 3 lines should be consumed (last one as a nested item); "
+        f"got new_idx={new_idx}"
+    )
+
+
+def test_markdown_to_word_with_mixed_valid_and_invalid_lists(use_default_template):
+    """End-to-end: the user's invalid input does NOT prevent valid content
+    from being rendered. The bug-trigger lines become plain paragraphs;
+    the rest of the document is processed normally."""
+    md = (
+        "Intro.\n"
+        "\n"
+        "   1. Indented (bug trigger)\n"
+        "   2. Another indented\n"
+        "\n"
+        "1. First valid ordered\n"
+        "2. Second valid ordered\n"
+        "\n"
+        "   - Indented bullet (bug trigger)\n"
+        "\n"
+        "- First valid bullet\n"
+        "- Second valid bullet\n"
+        "\n"
+        "Outro.\n"
+    )
+
+    completed, result, error = _run_in_thread(md, timeout=10)
+
+    assert completed, "markdown_to_word did not complete on mixed valid+invalid"
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+def test_process_list_items_handles_empty_lines_input():
+    """Pure empty/whitespace input must terminate immediately.
+
+    The function is documented to consume list items; if there are no
+    list items at start_idx, it must still return ``new_idx > start_idx``
+    so the caller is not stuck.
+    """
+    lines = [""]
+    doc = _new_blank_doc()
+    new_idx, _ = process_list_items(lines, 0, doc, is_ordered=True, level=0)
+    assert new_idx > 0
+
+
+def test_process_list_items_handles_non_list_input():
+    """A plain paragraph line at start_idx (not a list pattern at all)
+    must still result in forward progress.
+
+    This case can be reached if a future caller dispatches incorrectly,
+    or if the input contains a list pattern only on the stripped form
+    but not in the cleaned line (e.g. unusual whitespace). The guard
+    catches every "no-progress" scenario uniformly.
+    """
+    lines = ["This is not a list line."]
+    doc = _new_blank_doc()
+    new_idx, _ = process_list_items(lines, 0, doc, is_ordered=True, level=0)
+    assert new_idx > 0
+
+
+def test_process_list_items_recursive_call_unaffected_by_guard():
+    """The forward-progress guard must be a no-op for recursive calls.
+
+    When ``process_list_items`` recurses for nested items it passes the
+    nested level explicitly. The first iteration's indent matches that
+    level by construction, so the function consumes at least one item
+    and the guard at the end never fires. This test asserts that
+    behaviour is unchanged: a flat list with a nested sub-list produces
+    the expected paragraphs and styles, exactly as before the fix.
+    """
+    lines = [
+        "- Outer item",
+        "   - Nested item",
+    ]
+    doc = _new_doc_with_default_styles()
+    initial = len(doc.paragraphs)
+
+    new_idx, _ = process_list_items(lines, 0, doc, is_ordered=False, level=0)
+
+    assert new_idx == 2
+    new_paragraphs = doc.paragraphs[initial:]
+    text_and_style = [(p.text, p.style.name) for p in new_paragraphs]
+    assert text_and_style == [
+        ("Outer item", "List Bullet"),
+        ("Nested item", "List Bullet 2"),
+    ], (
+        "Recursive descent for nested items behaves differently after the "
+        "forward-progress guard was added — the guard should be a no-op "
+        f"in the recursion path. Got: {text_and_style}"
+    )
+
+
+def test_process_list_items_return_elements_mode_works_with_guard():
+    """The ``return_elements=True`` mode (used by template-placeholder
+    rendering in ``dynamic_docx_tools``) must keep working — both on the
+    happy path and when the guard fires.
+
+    On the happy path the guard is a no-op. When the guard fires for a
+    bug-trigger line, the fallback paragraph it creates is also detached
+    from the body and appended to ``elements``, matching the rest of the
+    function's contract.
+    """
+    # Happy path with return_elements=True
+    happy_lines = ["1. Captured item"]
+    doc = _new_doc_with_default_styles()
+    new_idx, elements = process_list_items(
+        happy_lines, 0, doc, is_ordered=True, level=0, return_elements=True
+    )
+    assert new_idx == 1
+    assert elements is not None and len(elements) == 1, (
+        f"Expected one element returned on happy path; got {elements}"
+    )
+
+    # Guard path with return_elements=True — bug-trigger line should
+    # produce one fallback element and still advance.
+    guarded_lines = ["   1. Indented (bug trigger)"]
+    doc2 = _new_doc_with_default_styles()
+    new_idx2, elements2 = process_list_items(
+        guarded_lines, 0, doc2, is_ordered=True, level=0, return_elements=True
+    )
+    assert new_idx2 == 1
+    assert elements2 is not None and len(elements2) == 1, (
+        "Forward-progress guard with return_elements=True did not append "
+        f"the fallback paragraph to elements; got {elements2}"
+    )
+
+
+def test_markdown_to_word_with_only_indented_list_completes(use_default_template):
+    """Worst-case input: the entire document is bug-trigger lines.
+
+    Even when every list line in the document has leading whitespace,
+    ``markdown_to_word`` must terminate. Each line gets rendered as a
+    plain paragraph via the guard."""
+    md = (
+        "   1. Indented one\n"
+        "   2. Indented two\n"
+        "   3. Indented three\n"
+    )
+
+    completed, result, error = _run_in_thread(md, timeout=10)
+    assert completed
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+def test_markdown_to_word_on_empty_input(use_default_template):
+    """Empty markdown must not hang and must produce a (possibly empty)
+    document."""
+    completed, result, error = _run_in_thread("", timeout=10)
+    assert completed
+    if error is not None:
+        raise error
+    assert result is not None
+
+
+def test_markdown_to_word_on_whitespace_only_input(use_default_template):
+    """Whitespace-only input (newlines and spaces) must terminate too."""
+    completed, result, error = _run_in_thread("\n   \n\n   \n", timeout=10)
+    assert completed
+    if error is not None:
+        raise error
+    assert result is not None

--- a/tests/test_run_blocking.py
+++ b/tests/test_run_blocking.py
@@ -24,6 +24,7 @@ import asyncio
 import importlib
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -39,28 +40,30 @@ sys.path.insert(0, str(project_root))
 # Test helpers
 # ---------------------------------------------------------------------------
 
-def _reload_main_with_flag(flag_value: str):
-    """Re-import main.py with RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED set to *flag_value*.
+def _reload_main_with_flag(flag_value: str, max_workers: str | None = None):
+    """Re-import main.py with the run_blocking env vars set.
 
-    The Config singleton is reset before reload so the new env var is read.
-    Also clears any module that caches references to the config singleton
-    (``async_runner`` imports ``get_config`` at module load), so the freshly
-    reloaded config is the one that ``run_blocking`` consults.
+    Args:
+        flag_value: Value for ``RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED``.
+        max_workers: Optional value for ``RUN_BLOCKING_MAX_WORKERS``. When
+            ``None``, the env var is set to ``""`` so the parser falls
+            back to the documented default (4). Setting it explicitly
+            (including the empty string) rather than popping prevents
+            ``load_dotenv()`` from re-applying a developer's local
+            ``.env`` value on each ``config`` reimport.
 
-    Setting an explicit value (including the empty string) rather than
-    popping the env var prevents ``load_dotenv()`` — which runs on each
-    ``config`` reimport — from re-applying a developer's local ``.env``
-    value.
+    Modules reloaded together so that:
+      - config re-reads the environment,
+      - async_runner re-binds get_config and recreates the bounded
+        ThreadPoolExecutor with the freshly loaded max_workers,
+      - main re-binds run_blocking to the new async_runner module.
 
     Returns the freshly imported main module.
     """
     os.environ["RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED"] = flag_value
+    os.environ["RUN_BLOCKING_MAX_WORKERS"] = "" if max_workers is None else max_workers
     os.environ.setdefault("UPLOAD_STRATEGY", "LOCAL")
 
-    # Modules that must be reloaded together so that:
-    #   - config re-reads the environment,
-    #   - async_runner re-binds get_config to the new config module,
-    #   - main re-binds run_blocking to the new async_runner module.
     for mod_name in ("main", "async_runner", "config"):
         sys.modules.pop(mod_name, None)
 
@@ -89,21 +92,26 @@ def _raising_sync():
 class TestRunBlockingFlagPlumbing:
     """Verify the RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED env var maps to config correctly."""
 
-    def test_flag_default_is_false(self):
-        # Setting to empty string is equivalent to "unset" for our parser
-        # (_parse_bool returns False) AND prevents load_dotenv() from
-        # overriding it on re-import if the developer's local .env happens
-        # to set the flag to a truthy value.
-        main = _reload_main_with_flag("")
-        assert main.config.run_blocking_by_asyncio_thread_enabled is False
+    @pytest.mark.parametrize("unset_marker", ["", "  "])
+    def test_flag_default_is_true_when_unset(self, unset_marker):
+        """Empty / whitespace env value is treated as 'unset' → default True.
+
+        Setting an explicit value (even empty) rather than popping the var
+        prevents ``load_dotenv()`` from re-applying a developer's local
+        ``.env`` value on each ``config`` reimport.
+        """
+        main = _reload_main_with_flag(unset_marker)
+        assert main.config.run_blocking_by_asyncio_thread_enabled is True
 
     @pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on", "y"])
     def test_flag_truthy_values(self, truthy):
         main = _reload_main_with_flag(truthy)
         assert main.config.run_blocking_by_asyncio_thread_enabled is True
 
-    @pytest.mark.parametrize("falsy", ["0", "false", "", "no", "off", "  "])
-    def test_flag_falsy_values(self, falsy):
+    @pytest.mark.parametrize("falsy", ["0", "false", "no", "off"])
+    def test_flag_explicit_falsy_values(self, falsy):
+        """Only explicit falsy strings disable the offload (empty / whitespace
+        falls back to the True default — see test_flag_default_is_true_when_unset)."""
         main = _reload_main_with_flag(falsy)
         assert main.config.run_blocking_by_asyncio_thread_enabled is False
 
@@ -291,3 +299,130 @@ class TestDynamicToolsUseRunBlocking:
         assert inspect.iscoroutinefunction(docx_rb)
         assert inspect.iscoroutinefunction(email_rb)
         assert main.config.run_blocking_by_asyncio_thread_enabled is expected_mode
+
+
+# ---------------------------------------------------------------------------
+# Bounded executor — config + behavioural tests
+# ---------------------------------------------------------------------------
+
+class TestBoundedExecutorConfig:
+    """Verify RUN_BLOCKING_MAX_WORKERS maps to config and to the executor."""
+
+    def test_default_is_4(self):
+        """No env var set → config default of 4 is used."""
+        main = _reload_main_with_flag("true", max_workers="")
+        assert main.config.run_blocking_max_workers == 4
+
+    @pytest.mark.parametrize("n", [1, 2, 3, 8, 16])
+    def test_env_override_accepted(self, n):
+        """Valid positive integer env values are honoured."""
+        main = _reload_main_with_flag("true", max_workers=str(n))
+        assert main.config.run_blocking_max_workers == n
+
+    @pytest.mark.parametrize("bogus", ["0", "-3", "not-an-int", "  "])
+    def test_invalid_env_falls_back_to_default(self, bogus):
+        """Invalid / non-positive values silently fall back to default 4."""
+        main = _reload_main_with_flag("true", max_workers=bogus)
+        assert main.config.run_blocking_max_workers == 4
+
+
+class TestBoundedExecutorBehavior:
+    """Verify the executor is bounded and the GIL pile-up is prevented."""
+
+    def test_executor_is_created_lazily_and_has_config_size(self):
+        """First call must create a ThreadPoolExecutor sized from config."""
+        _reload_main_with_flag("true", max_workers="3")
+        from async_runner import _get_executor
+
+        ex = _get_executor()
+        # ThreadPoolExecutor exposes max_workers as a public attribute.
+        assert ex._max_workers == 3
+        # And subsequent calls must return the same instance (singleton).
+        assert _get_executor() is ex
+
+    def test_executor_uses_named_threads(self):
+        """Worker threads carry the documented prefix — useful in py-spy dumps."""
+        _reload_main_with_flag("true", max_workers="2")
+        from async_runner import _get_executor
+
+        captured: list[str] = []
+
+        def record_thread_name():
+            captured.append(threading.current_thread().name)
+
+        ex = _get_executor()
+        fut = ex.submit(record_thread_name)
+        fut.result(timeout=5)
+
+        assert captured, "task did not run"
+        assert captured[0].startswith("run_blocking"), (
+            f"thread name {captured[0]!r} should start with 'run_blocking' so "
+            f"py-spy / logs make the bounded pool obvious"
+        )
+
+    def test_concurrent_runs_are_capped_at_max_workers(self):
+        """With max_workers=2, never more than 2 tasks execute simultaneously.
+
+        This is the core safety property: more than max_workers concurrent
+        offloaded calls must QUEUE in the executor, not start spawning
+        unbounded threads that all compete for the GIL.
+        """
+        _reload_main_with_flag("true", max_workers="2")
+        from async_runner import run_blocking
+
+        # We submit 8 tasks that each "hold a slot" for a short window.
+        # A shared counter records how many are concurrently active; the
+        # peak must equal max_workers (2), never exceed it.
+        active = 0
+        peak = 0
+        lock = threading.Lock()
+        barrier_release = threading.Event()
+
+        def slot_holder():
+            nonlocal active, peak
+            with lock:
+                active += 1
+                if active > peak:
+                    peak = active
+            # Hold the slot briefly so the scheduler has a real chance to
+            # pile more in if the bound is broken.
+            time.sleep(0.05)
+            with lock:
+                active -= 1
+            return True
+
+        async def run_many():
+            await asyncio.gather(*[run_blocking(slot_holder) for _ in range(8)])
+
+        asyncio.run(run_many())
+
+        assert peak == 2, (
+            f"peak concurrent workers was {peak}, expected exactly 2 "
+            f"(max_workers). Bound is broken — GIL pile-up will recur."
+        )
+
+    def test_inline_mode_does_not_use_executor(self):
+        """When the thread-offload flag is disabled, no executor work happens."""
+        _reload_main_with_flag("false", max_workers="2")
+        from async_runner import run_blocking
+
+        # Capture which thread the function runs on. In inline mode it
+        # must be the asyncio loop thread (i.e. NOT a 'run_blocking_*'
+        # worker thread).
+        observed: list[str] = []
+
+        def record_thread():
+            observed.append(threading.current_thread().name)
+            return 42
+
+        async def go():
+            result = await run_blocking(record_thread)
+            assert result == 42
+
+        asyncio.run(go())
+
+        assert observed, "function did not run"
+        assert not observed[0].startswith("run_blocking"), (
+            f"inline mode must not touch the bounded executor; saw thread "
+            f"{observed[0]!r}"
+        )

--- a/tests/test_run_blocking.py
+++ b/tests/test_run_blocking.py
@@ -1,0 +1,293 @@
+"""Tests for the run_blocking() helper and its RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED toggle.
+
+The helper in main.py dispatches synchronous document-generation work to
+either:
+
+1. The event loop directly (inline) — when RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED is false
+   or unset. This is the legacy behavior; the loop blocks for the full
+   duration of the call.
+2. A worker thread via ``asyncio.to_thread`` — when RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED
+   is truthy. The loop stays free to serve health probes and concurrent
+   requests.
+
+These tests verify both modes:
+
+- Mode selection follows the env var.
+- The helper returns the wrapped function's value in both modes.
+- Exceptions propagate in both modes.
+- In offload mode, the event loop remains responsive during a long
+  blocking call.
+- In inline mode, the event loop is blocked (legacy behavior).
+"""
+
+import asyncio
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _reload_main_with_flag(flag_value: str):
+    """Re-import main.py with RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED set to *flag_value*.
+
+    The Config singleton is reset before reload so the new env var is read.
+    Also clears any module that caches references to the config singleton
+    (``async_runner`` imports ``get_config`` at module load), so the freshly
+    reloaded config is the one that ``run_blocking`` consults.
+
+    Setting an explicit value (including the empty string) rather than
+    popping the env var prevents ``load_dotenv()`` — which runs on each
+    ``config`` reimport — from re-applying a developer's local ``.env``
+    value.
+
+    Returns the freshly imported main module.
+    """
+    os.environ["RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED"] = flag_value
+    os.environ.setdefault("UPLOAD_STRATEGY", "LOCAL")
+
+    # Modules that must be reloaded together so that:
+    #   - config re-reads the environment,
+    #   - async_runner re-binds get_config to the new config module,
+    #   - main re-binds run_blocking to the new async_runner module.
+    for mod_name in ("main", "async_runner", "config"):
+        sys.modules.pop(mod_name, None)
+
+    # Defensively reset the config singleton before main reads it.
+    import config as cfg_mod
+    cfg_mod._CONFIG = None
+
+    return importlib.import_module("main")
+
+
+def _slow_sync(duration_s: float, return_value: Any = "ok"):
+    """Synchronous sleep — emulates a blocking document-generation call."""
+    time.sleep(duration_s)
+    return return_value
+
+
+def _raising_sync():
+    """Synchronous function that always raises — for exception-path tests."""
+    raise RuntimeError("boom from worker")
+
+
+# ---------------------------------------------------------------------------
+# Config-flag plumbing
+# ---------------------------------------------------------------------------
+
+class TestRunBlockingFlagPlumbing:
+    """Verify the RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED env var maps to config correctly."""
+
+    def test_flag_default_is_false(self):
+        # Setting to empty string is equivalent to "unset" for our parser
+        # (_parse_bool returns False) AND prevents load_dotenv() from
+        # overriding it on re-import if the developer's local .env happens
+        # to set the flag to a truthy value.
+        main = _reload_main_with_flag("")
+        assert main.config.run_blocking_by_asyncio_thread_enabled is False
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on", "y"])
+    def test_flag_truthy_values(self, truthy):
+        main = _reload_main_with_flag(truthy)
+        assert main.config.run_blocking_by_asyncio_thread_enabled is True
+
+    @pytest.mark.parametrize("falsy", ["0", "false", "", "no", "off", "  "])
+    def test_flag_falsy_values(self, falsy):
+        main = _reload_main_with_flag(falsy)
+        assert main.config.run_blocking_by_asyncio_thread_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Functional behavior in both modes
+# ---------------------------------------------------------------------------
+
+class TestRunBlockingFunctional:
+    """Verify run_blocking returns values and propagates exceptions in both modes."""
+
+    @pytest.mark.parametrize("flag,expected_mode", [("false", False), ("true", True)])
+    def test_returns_wrapped_value(self, flag, expected_mode):
+        main = _reload_main_with_flag(flag)
+        assert main.config.run_blocking_by_asyncio_thread_enabled is expected_mode
+
+        result = asyncio.run(main.run_blocking(_slow_sync, 0.0, return_value=42))
+        assert result == 42
+
+    @pytest.mark.parametrize("flag", ["false", "true"])
+    def test_propagates_exceptions(self, flag):
+        main = _reload_main_with_flag(flag)
+        with pytest.raises(RuntimeError, match="boom from worker"):
+            asyncio.run(main.run_blocking(_raising_sync))
+
+    @pytest.mark.parametrize("flag", ["false", "true"])
+    def test_passes_args_and_kwargs(self, flag):
+        main = _reload_main_with_flag(flag)
+
+        def fn(a, b, *, c, d=10):
+            return (a, b, c, d)
+
+        result = asyncio.run(main.run_blocking(fn, 1, 2, c=3, d=4))
+        assert result == (1, 2, 3, 4)
+
+
+# ---------------------------------------------------------------------------
+# Event-loop responsiveness — the whole reason this helper exists
+# ---------------------------------------------------------------------------
+
+class TestEventLoopBehavior:
+    """Distinguish inline vs offload modes by observing loop behavior.
+
+    The clearest signal: how long a small ``await asyncio.sleep(0.01)``
+    actually takes while a 1-second blocking call is also in flight.
+    """
+
+    @staticmethod
+    async def _measure_yield_latency_while_blocking(main_mod, slow_duration_s: float):
+        """Return the max latency of 10 ``asyncio.sleep(0.01)`` calls while
+        a slow blocking call runs concurrently."""
+        latencies = []
+
+        async def run_slow():
+            await main_mod.run_blocking(_slow_sync, slow_duration_s)
+
+        slow_task = asyncio.create_task(run_slow())
+        # Let the slow task start
+        await asyncio.sleep(0.05)
+
+        for _ in range(10):
+            t0 = time.perf_counter()
+            await asyncio.sleep(0.01)
+            latencies.append((time.perf_counter() - t0) * 1000)  # ms
+
+        await slow_task
+        return max(latencies), latencies
+
+    def test_offload_mode_keeps_loop_responsive(self):
+        """With offload enabled, yield latency stays close to the 10ms target."""
+        main = _reload_main_with_flag("true")
+        max_latency, _ = asyncio.run(
+            self._measure_yield_latency_while_blocking(main, slow_duration_s=1.0)
+        )
+        # Allow generous headroom; in practice this should be ~11ms.
+        assert max_latency < 50, (
+            f"Loop appears blocked in offload mode: max yield latency "
+            f"{max_latency:.1f} ms (expected <50ms)"
+        )
+
+    def test_inline_mode_blocks_loop(self):
+        """With offload disabled, the loop is blocked during the sync call.
+
+        We run a slow sync call concurrently with a 0.5s asyncio.sleep and
+        measure total elapsed time. In inline mode, the loop can't service
+        the asyncio.sleep until the sync call finishes, so total time is
+        ~1.5s (sequential). In offload mode it would be ~1.0s (concurrent).
+        """
+        main = _reload_main_with_flag("false")
+
+        async def race():
+            t0 = time.perf_counter()
+            await asyncio.gather(
+                main.run_blocking(_slow_sync, 1.0),
+                asyncio.sleep(0.5),
+            )
+            return time.perf_counter() - t0
+
+        elapsed = asyncio.run(race())
+        # Inline: ~1.5s (sequential). Offload would be ~1.0s.
+        assert elapsed > 1.3, (
+            f"Expected inline mode to serialize the sync call and async sleep "
+            f"(~1.5s total), got {elapsed:.3f}s — looks like offload mode."
+        )
+
+    def test_offload_mode_overlaps_blocking_and_async(self):
+        """With offload, a 1s sync call + 0.5s asyncio.sleep finishes in ~1s."""
+        main = _reload_main_with_flag("true")
+
+        async def race():
+            t0 = time.perf_counter()
+            await asyncio.gather(
+                main.run_blocking(_slow_sync, 1.0),
+                asyncio.sleep(0.5),
+            )
+            return time.perf_counter() - t0
+
+        elapsed = asyncio.run(race())
+        # Offload: ~1.0s (concurrent). Should be < 1.3s.
+        assert elapsed < 1.3, (
+            f"Expected offload mode to overlap sync work with async work "
+            f"(~1.0s total), got {elapsed:.3f}s — looks like inline mode."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic tool integration — verify dynamic_docx / dynamic_email tools also
+# go through run_blocking and follow the same flag as static tools.
+# ---------------------------------------------------------------------------
+
+class TestDynamicToolsUseRunBlocking:
+    """Confirm dynamic tool registrations route through run_blocking.
+
+    The dynamic registrars build an ``async def tool_impl(data)`` that
+    delegates to ``await run_blocking(_sync_impl, data)``. We assert that
+    the registered tools are coroutine functions (not plain ``def``), and
+    that they execute end-to-end in both modes.
+    """
+
+    @pytest.mark.parametrize("flag", ["false", "true"])
+    def test_dynamic_docx_tool_is_async_and_runs(self, flag):
+        main = _reload_main_with_flag(flag)
+
+        # Pull a registered dynamic docx tool from the mcp instance.
+        # FastMCP stores tools internally; we look one up by name. The
+        # actual tool function is exposed via the Tool object's `fn`.
+        # We use the lower-level access pattern so this test stays
+        # independent of FastMCP's public surface evolving.
+        tool = asyncio.run(main.mcp.get_tool("formal_letter"))
+        assert tool is not None, "dynamic tool 'formal_letter' was not registered"
+
+        import inspect
+        assert inspect.iscoroutinefunction(tool.fn), (
+            "dynamic docx tool_impl should be async def so run_blocking governs dispatch"
+        )
+
+    @pytest.mark.parametrize("flag", ["false", "true"])
+    def test_dynamic_email_tool_is_async_and_runs(self, flag):
+        main = _reload_main_with_flag(flag)
+
+        # bu_broadcast_email_style_1 is registered from config/email_templates.yaml
+        tool = asyncio.run(main.mcp.get_tool("bu_broadcast_email_style_1"))
+        assert tool is not None, "dynamic email tool was not registered"
+
+        import inspect
+        assert inspect.iscoroutinefunction(tool.fn), (
+            "dynamic email tool_impl should be async def so run_blocking governs dispatch"
+        )
+
+    @pytest.mark.parametrize("flag,expected_mode", [("false", False), ("true", True)])
+    def test_run_blocking_helper_imported_by_dynamic_modules(self, flag, expected_mode):
+        """Both dynamic modules import run_blocking from async_runner."""
+        main = _reload_main_with_flag(flag)
+
+        # Each dynamic module must expose a `run_blocking` symbol that is
+        # an async function. We don't require identity with the freshly
+        # reloaded async_runner.run_blocking because reloading async_runner
+        # produces a new function object while the dynamic modules retain
+        # the import they bound at *their* first import time — which is
+        # still functionally correct (it reads config.get_config() lazily).
+        import inspect
+        from docx_tools.dynamic_docx_tools import run_blocking as docx_rb
+        from email_tools.dynamic_email_tools import run_blocking as email_rb
+
+        assert inspect.iscoroutinefunction(docx_rb)
+        assert inspect.iscoroutinefunction(email_rb)
+        assert main.config.run_blocking_by_asyncio_thread_enabled is expected_mode


### PR DESCRIPTION
**Current issue:** Every Office-document generator in this project (e.g., ``markdown_to_word``, ``markdown_to_excel`` etc. and every dynamically-registered template tool) is a synchronous, blocking function. FastMCP runs on top of an asyncio event loop (uvicorn / Starlette). Calling a blocking function directly from an ``async def`` MCP tool handler freezes the loop for the full duration of the call — no other request can be served, including the Kubernetes liveness / readiness probes.

**Changes to address this:**
Whether blocking work is offloaded to a worker thread is controlled by
the ``RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED`` environment variable
(see ``config.Config.run_blocking_by_asyncio_thread_enabled``):

  * Disabled (default) — call the sync function inline on the event
    loop. The loop is blocked until the call returns. This is the
    legacy behaviour for static tools; dynamic tools (previously
    registered as sync ``def`` and auto-threaded by FastMCP) will also
    run on the event loop in this mode, since the dynamic handlers are
    now ``async def`` wrappers around ``run_blocking``.
  * Enabled — dispatch the sync function to asyncio's default thread
    pool via ``asyncio.to_thread``. The event loop stays free to serve
    health probes and concurrent requests. Recommended for EKS.  

Additionally, a few health probes (/healthz, /readyz, /livez) are added.   