### PR TITLE
feat: conditional templates for DOCX+PPTX — if/unless/each syntax

### DIFF
--- a/docx_tools/conditional_templates.py
+++ b/docx_tools/conditional_templates.py
@@ -1,0 +1,111 @@
+"""Conditional templates for DOCX and PPTX — if/else blocks and loops."""
+
+import re
+from docx import Document
+from pptx import Presentation
+
+
+def render_docx_template(file_path: str, context: dict, output_path: str | None = None) -> str:
+    """Render a DOCX template with conditional blocks and loops.
+
+    Supports:
+    - {{variable}} — simple replacement
+    - {{#if condition}}...{{/if}} — conditional block (truthy check)
+    - {{#unless condition}}...{{/unless}} — inverse conditional
+    - {{#each items}}...{{/each}} — loop over list (use {{.}} for item)
+    """
+    doc = Document(file_path)
+
+    for para in doc.paragraphs:
+        para.text = _render_text(para.text, context)
+
+    # Also process tables
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                for para in cell.paragraphs:
+                    para.text = _render_text(para.text, context)
+
+    save_path = output_path or file_path
+    doc.save(save_path)
+    return f"Template rendered with {len(context)} variables. Saved to {save_path}"
+
+
+def render_pptx_template(file_path: str, context: dict, output_path: str | None = None) -> str:
+    """Render a PPTX template with conditional blocks and loops."""
+    prs = Presentation(file_path)
+
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                for para in shape.text_frame.paragraphs:
+                    full_text = "".join(run.text for run in para.runs)
+                    rendered = _render_text(full_text, context)
+                    if rendered != full_text:
+                        # Clear runs and set new text
+                        for run in para.runs:
+                            run.text = ""
+                        if para.runs:
+                            para.runs[0].text = rendered
+
+    save_path = output_path or file_path
+    prs.save(save_path)
+    return f"PPTX template rendered with {len(context)} variables. Saved to {save_path}"
+
+
+def _render_text(text: str, context: dict) -> str:
+    """Process template syntax in text."""
+    # Process {{#each items}}...{{/each}}
+    each_pattern = r"\{\{#each\s+(\w+)\}\}(.*?)\{\{/each\}\}"
+    def replace_each(match):
+        key = match.group(1)
+        body = match.group(2)
+        items = context.get(key, [])
+        if not isinstance(items, list):
+            return ""
+        result = []
+        for item in items:
+            if isinstance(item, dict):
+                rendered = body
+                for k, v in item.items():
+                    rendered = rendered.replace(f"{{{{{k}}}}}", str(v))
+                result.append(rendered)
+            else:
+                result.append(body.replace("{{.}}", str(item)))
+        return "\n".join(result)
+
+    text = re.sub(each_pattern, replace_each, text, flags=re.DOTALL)
+
+    # Process {{#if condition}}...{{/if}}
+    if_pattern = r"\{\{#if\s+(\w+)\}\}(.*?)\{\{/if\}\}"
+    def replace_if(match):
+        key = match.group(1)
+        body = match.group(2)
+        value = context.get(key)
+        if value:
+            return body
+        return ""
+
+    text = re.sub(if_pattern, replace_if, text, flags=re.DOTALL)
+
+    # Process {{#unless condition}}...{{/unless}}
+    unless_pattern = r"\{\{#unless\s+(\w+)\}\}(.*?)\{\{/unless\}\}"
+    def replace_unless(match):
+        key = match.group(1)
+        body = match.group(2)
+        value = context.get(key)
+        if not value:
+            return body
+        return ""
+
+    text = re.sub(unless_pattern, replace_unless, text, flags=re.DOTALL)
+
+    # Process simple {{variable}} replacements
+    simple_pattern = r"\{\{(\w+)\}\}"
+    def replace_simple(match):
+        key = match.group(1)
+        return str(context.get(key, match.group(0)))
+
+    text = re.sub(simple_pattern, replace_simple, text)
+
+    return text

--- a/tests/test_conditional_templates.py
+++ b/tests/test_conditional_templates.py
@@ -1,0 +1,87 @@
+"""Tests for conditional templates (DOCX + PPTX)."""
+
+import pytest
+from docx import Document
+from pptx import Presentation
+
+from docx_tools.conditional_templates import render_docx_template, render_pptx_template, _render_text
+
+
+class TestRenderText:
+    def test_simple_variable(self):
+        assert _render_text("Hello {{name}}", {"name": "World"}) == "Hello World"
+
+    def test_missing_variable_unchanged(self):
+        assert _render_text("{{unknown}}", {}) == "{{unknown}}"
+
+    def test_if_true(self):
+        text = "{{#if show}}Visible{{/if}}"
+        assert _render_text(text, {"show": True}) == "Visible"
+
+    def test_if_false(self):
+        text = "{{#if show}}Visible{{/if}}"
+        assert _render_text(text, {"show": False}) == ""
+
+    def test_unless_true(self):
+        text = "{{#unless premium}}Free tier{{/unless}}"
+        assert _render_text(text, {"premium": True}) == ""
+
+    def test_unless_false(self):
+        text = "{{#unless premium}}Free tier{{/unless}}"
+        assert _render_text(text, {"premium": False}) == "Free tier"
+
+    def test_each_simple(self):
+        text = "{{#each items}}{{.}}, {{/each}}"
+        result = _render_text(text, {"items": ["A", "B", "C"]})
+        assert "A" in result and "B" in result and "C" in result
+
+    def test_each_dict(self):
+        text = "{{#each people}}{{name}} ({{age}}), {{/each}}"
+        result = _render_text(text, {"people": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]})
+        assert "Alice (30)" in result
+        assert "Bob (25)" in result
+
+    def test_each_empty(self):
+        text = "{{#each items}}{{.}}{{/each}}"
+        assert _render_text(text, {"items": []}) == ""
+
+
+class TestRenderDocxTemplate:
+    def test_render_simple(self, tmp_path):
+        path = str(tmp_path / "tpl.docx")
+        doc = Document()
+        doc.add_paragraph("Dear {{name}},")
+        doc.add_paragraph("{{#if vip}}VIP access granted.{{/if}}")
+        doc.save(path)
+
+        out = str(tmp_path / "out.docx")
+        render_docx_template(path, {"name": "Alice", "vip": True}, out)
+        result = Document(out)
+        assert result.paragraphs[0].text == "Dear Alice,"
+        assert result.paragraphs[1].text == "VIP access granted."
+
+    def test_render_loop(self, tmp_path):
+        path = str(tmp_path / "tpl.docx")
+        doc = Document()
+        doc.add_paragraph("Items: {{#each items}}{{.}}, {{/each}}")
+        doc.save(path)
+
+        out = str(tmp_path / "out.docx")
+        render_docx_template(path, {"items": ["X", "Y", "Z"]}, out)
+        result = Document(out)
+        assert "X" in result.paragraphs[0].text
+
+
+class TestRenderPptxTemplate:
+    def test_render_pptx(self, tmp_path):
+        path = str(tmp_path / "tpl.pptx")
+        prs = Presentation()
+        slide = prs.slides.add_slide(prs.slide_layouts[0])
+        slide.shapes.title.text = "{{title}}"
+        slide.placeholders[1].text = "By {{author}}"
+        prs.save(path)
+
+        out = str(tmp_path / "out.pptx")
+        render_pptx_template(path, {"title": "My Talk", "author": "Alice"}, out)
+        result = Presentation(out)
+        assert result.slides[0].shapes.title.text == "My Talk"


### PR DESCRIPTION
Addresses #55 items 1 and 3.

## What

Adds a template engine that supports conditional blocks and loops in DOCX and PPTX files:

- `{{variable}}` — simple replacement
- `{{#if condition}}...{{/if}}` — conditional block
- `{{#unless condition}}...{{/unless}}` — inverse conditional
- `{{#each items}}...{{/each}}` — loop (supports dicts and simple lists)

## Files

- `docx_tools/conditional_templates.py` — render_docx_template, render_pptx_template
- `tests/test_conditional_templates.py` — 12 tests

## Integration

These are standalone functions. To register as MCP tools, add to `main.py`:

```python
from docx_tools.conditional_templates import render_docx_template, render_pptx_template
```

Kept separate to let you decide the tool schema/naming.

## Tests

```bash
pytest tests/test_conditional_templates.py -v  # 12 pass
```