### PR TITLE
fix(docx): disambiguate numbered-list dates and preserve placeholder formatting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,6 +242,8 @@ Both the Word and Excel tools accept Markdown. These references cover **everythi
 | `# H1` … `###### H6` | Headings 1–6 |
 | `- item` / `* item` / `+ item` | Bullet list (nest by indenting children — 2-4 spaces or a tab → `List Bullet 2/3`) |
 | `1. item` / `2. item` | Numbered list (nest by indenting children). **Numbering restarts automatically** whenever a list begins again with `1.` |
+
+> 💡 A single numbered line is only treated as a list when it starts at `1.` **or** is followed by another item. This means a standalone date like `23. června 2026` renders as plain text, not a list. The one exception is a day-1 date (`1. června 2026`), which is indistinguishable from a one-item list — escape the dot to keep it as text: `1\. června 2026`.
 | `> quote` | Block quote (`Quote` style) |
 | `\| A \| B \|` + `\|---\|---\|` | Table (see table features below) |
 | ` ``` ` … ` ``` ` (or `~~~`) | Fenced code block — content is rendered verbatim in a monospace font and **not** parsed as markdown |
@@ -262,7 +264,7 @@ Both the Word and Excel tools accept Markdown. These references cover **everythi
 | `` `code` `` | Monospace (Courier New) |
 | `^super^` · `~sub~` | Superscript (`x^2^`) / subscript (`H~2~O`) |
 | `[text](url)` | Hyperlink |
-| `\*` `\**` `` \` `` | Escaped literals (render the marker as text) |
+| `\*` `\**` `` \` `` `\.` | Escaped literals (render the marker as text — e.g. `1\.` keeps a day-1 date from becoming a list) |
 
 Nesting and combinations work, e.g. `**bold with *italic* inside**`, `**~~bold strikethrough~~**`.
 
@@ -465,7 +467,8 @@ Subject: {{subject}}
 - Each template becomes a separate AI tool at startup
 - Placeholders can be in the document body, tables, headers, and footers
 - Placeholder values support full Markdown (bold, italic, lists, headings…)
-- The original font from the placeholder location is preserved
+- The placeholder's own formatting — font, size, colour, **bold, italic, underline, highlight** — is captured and applied to the replacement text (markdown in the value, e.g. `**bold**`, still wins where it sets formatting)
+- Formatting of the surrounding text in the same paragraph (before/after the placeholder) is preserved
 
 </details>
 

--- a/Readme.md
+++ b/Readme.md
@@ -242,8 +242,6 @@ Both the Word and Excel tools accept Markdown. These references cover **everythi
 | `# H1` … `###### H6` | Headings 1–6 |
 | `- item` / `* item` / `+ item` | Bullet list (nest by indenting children — 2-4 spaces or a tab → `List Bullet 2/3`) |
 | `1. item` / `2. item` | Numbered list (nest by indenting children). **Numbering restarts automatically** whenever a list begins again with `1.` |
-
-> 💡 A single numbered line is only treated as a list when it starts at `1.` **or** is followed by another item. This means a standalone date like `23. června 2026` renders as plain text, not a list. The one exception is a day-1 date (`1. června 2026`), which is indistinguishable from a one-item list — escape the dot to keep it as text: `1\. června 2026`.
 | `> quote` | Block quote (`Quote` style) |
 | `\| A \| B \|` + `\|---\|---\|` | Table (see table features below) |
 | ` ``` ` … ` ``` ` (or `~~~`) | Fenced code block — content is rendered verbatim in a monospace font and **not** parsed as markdown |
@@ -252,6 +250,8 @@ Both the Word and Excel tools accept Markdown. These references cover **everythi
 | `***` (3+ asterisks) | Horizontal line (visual separator) |
 
 > ⚠️ Don't confuse `---` (page break) with `***` (horizontal line).
+
+> 💡 A single numbered line is only treated as a list when it starts at `1.` **or** is followed by another item. This means a standalone date like `23. června 2026` renders as plain text, not a list. The one exception is a day-1 date (`1. června 2026`), which is indistinguishable from a one-item list — escape the dot to keep it as text: `1\. června 2026`.
 
 **Inline formatting** (works in paragraphs, headings, list items, table cells, quotes):
 

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -30,12 +30,14 @@ from __future__ import annotations
 
 import io
 import re
+import copy
 import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Literal
 
 import yaml
 from docx import Document as DocxDocument
+from docx.oxml.ns import qn
 from docx.text.paragraph import Paragraph
 from docx.table import Table
 from pydantic import Field, create_model
@@ -117,6 +119,67 @@ def find_docx_template_by_name(filename: str) -> Optional[str]:
     return str(found) if found else None
 
 
+def _copy_run_format(src_run, dst_run) -> None:
+    """Copy *src_run*'s character formatting onto *dst_run*.
+
+    Deep-copies the source run properties element (``<w:rPr>``) so every direct
+    format — bold, italic, underline, colour, highlight, font, character style —
+    is preserved wholesale, rather than enumerating individual properties.
+    """
+    src_rpr = src_run._r.find(qn('w:rPr'))
+    if src_rpr is None:
+        return
+    dst_rpr = dst_run._r.find(qn('w:rPr'))
+    if dst_rpr is not None:
+        dst_run._r.remove(dst_rpr)
+    dst_run._r.insert(0, copy.deepcopy(src_rpr))  # rPr must be the run's first child
+
+
+def _add_formatted_segments(paragraph, segments) -> None:
+    """Append *segments* (``(text, source_run)`` pairs) as runs, keeping format."""
+    for seg_text, seg_run in segments:
+        _copy_run_format(seg_run, paragraph.add_run(seg_text))
+
+
+def _segments_for_range(run_info, lo: int, hi: int):
+    """Return ``(text, run)`` pairs for the part of each run within ``[lo, hi)``.
+
+    Splits the surrounding text at the placeholder boundary while remembering
+    which original run each slice came from, so its formatting can be restored.
+    """
+    segments = []
+    for start, end, run in run_info:
+        seg_lo = max(start, lo)
+        seg_hi = min(end, hi)
+        if seg_lo < seg_hi:
+            segments.append((run.text[seg_lo - start:seg_hi - start], run))
+    return segments
+
+
+def _apply_placeholder_format(run, fmt) -> None:
+    """Fill *run*'s unset formatting from the placeholder's captured format *fmt*.
+
+    Only properties the markdown value left unset (``None``) are filled, so
+    formatting the value asked for (e.g. ``**bold**``) is never clobbered.
+    """
+    if fmt['name'] and not run.font.name:
+        run.font.name = fmt['name']
+    if fmt['size'] and not run.font.size:
+        run.font.size = fmt['size']
+    if fmt['color_rgb'] and not run.font.color.rgb:
+        run.font.color.rgb = fmt['color_rgb']
+    elif fmt['color_theme'] and not run.font.color.theme_color:
+        run.font.color.theme_color = fmt['color_theme']
+    if fmt['bold'] and run.bold is None:
+        run.bold = True
+    if fmt['italic'] and run.italic is None:
+        run.italic = True
+    if fmt['underline'] and run.underline is None:
+        run.underline = fmt['underline']
+    if fmt['highlight'] and run.font.highlight_color is None:
+        run.font.highlight_color = fmt['highlight']
+
+
 def _replace_placeholder_in_paragraph(
     paragraph: Paragraph,
     placeholder: str,
@@ -176,18 +239,30 @@ def _replace_placeholder_in_paragraph(
                 formatting_run = run
                 break
 
-        font_name = formatting_run.font.name if formatting_run else None
-        font_size = formatting_run.font.size if formatting_run else None
-        font_color_rgb = formatting_run.font.color.rgb if formatting_run else None
-        font_color_theme = formatting_run.font.color.theme_color if formatting_run else None
+        # Capture the placeholder run's direct character formatting so it can be
+        # re-applied to the replacement text (font, colour, and the emphasis
+        # formats bold/italic/underline/highlight).
+        placeholder_format = {
+            'name': formatting_run.font.name if formatting_run else None,
+            'size': formatting_run.font.size if formatting_run else None,
+            'color_rgb': formatting_run.font.color.rgb if formatting_run else None,
+            'color_theme': formatting_run.font.color.theme_color if formatting_run else None,
+            'bold': formatting_run.bold if formatting_run else None,
+            'italic': formatting_run.italic if formatting_run else None,
+            'underline': formatting_run.underline if formatting_run else None,
+            'highlight': formatting_run.font.highlight_color if formatting_run else None,
+        }
 
         # Strategy: Rebuild the paragraph content
         # 1. Get text before placeholder
         # 2. Get replacement content (parsed markdown)
         # 3. Get text after placeholder
 
-        text_before = combined_text[:placeholder_start]
-        text_after = combined_text[placeholder_end:]
+        # Slice the surrounding text at the placeholder boundaries, remembering
+        # each slice's source run so its formatting can be restored (rather than
+        # flattening before/after text to plain runs).
+        before_segments = _segments_for_range(run_info, 0, placeholder_start)
+        after_segments = _segments_for_range(run_info, placeholder_end, len(combined_text))
 
         # Check if the value contains block-level content (lists, headings)
         has_block_content = contains_block_markdown(value)
@@ -197,45 +272,30 @@ def _replace_placeholder_in_paragraph(
         for run in runs:
             p_element.remove(run._r)
 
-        # Add text before placeholder (plain text, preserve any formatting would be complex)
-        if text_before:
-            paragraph.add_run(text_before)
+        # Re-add the text before the placeholder, preserving its formatting.
+        _add_formatted_segments(paragraph, before_segments)
 
         if has_block_content and doc is not None:
             # Insert block content after this paragraph
             _insert_markdown_content_after_paragraph(doc, paragraph, value, style_map)
 
-            # If there's text after, add it as a run to this paragraph
-            if text_after:
-                paragraph.add_run(text_after)
+            # Re-add the text after the placeholder, preserving its formatting.
+            _add_formatted_segments(paragraph, after_segments)
 
             # If the placeholder occupied the whole paragraph (no surrounding text),
             # the paragraph is now empty – remove it to avoid a spurious blank line.
-            if not text_before and not text_after:
+            if not before_segments and not after_segments:
                 p_element.getparent().remove(p_element)
         else:
-            # Simple inline replacement
-            # Parse and add the replacement value with markdown formatting
+            # Simple inline replacement. Parse the value into runs, then fill any
+            # formatting it left unset from the placeholder run's captured format.
+            runs_before_value = len(paragraph.runs)
             parse_inline_formatting(value, paragraph)
+            for run in list(paragraph.runs)[runs_before_value:]:
+                _apply_placeholder_format(run, placeholder_format)
 
-            # Apply font formatting to newly added runs (from replacement)
-            if font_name or font_size or font_color_rgb or font_color_theme:
-                # Get runs added after text_before
-                new_runs = list(paragraph.runs)
-                start_idx = 1 if text_before else 0
-                for run in new_runs[start_idx:]:
-                    if font_name and not run.font.name:
-                        run.font.name = font_name
-                    if font_size and not run.font.size:
-                        run.font.size = font_size
-                    if font_color_rgb and not run.font.color.rgb:
-                        run.font.color.rgb = font_color_rgb
-                    elif font_color_theme and not run.font.color.theme_color:
-                        run.font.color.theme_color = font_color_theme
-
-            # Add text after placeholder
-            if text_after:
-                paragraph.add_run(text_after)
+            # Re-add the text after the placeholder, preserving its formatting.
+            _add_formatted_segments(paragraph, after_segments)
 
         return True
 

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -170,11 +170,14 @@ def _apply_placeholder_format(run, fmt) -> None:
         run.font.color.rgb = fmt['color_rgb']
     elif fmt['color_theme'] and not run.font.color.theme_color:
         run.font.color.theme_color = fmt['color_theme']
-    if fmt['bold'] and run.bold is None:
-        run.bold = True
-    if fmt['italic'] and run.italic is None:
-        run.italic = True
-    if fmt['underline'] and run.underline is None:
+    # Emphasis formats are tri-state (None = inherit). Propagate the placeholder's
+    # explicit value — including an explicit False (e.g. bold turned off to
+    # counteract a paragraph style) — but never override what the markdown set.
+    if fmt['bold'] is not None and run.bold is None:
+        run.bold = fmt['bold']
+    if fmt['italic'] is not None and run.italic is None:
+        run.italic = fmt['italic']
+    if fmt['underline'] is not None and run.underline is None:
         run.underline = fmt['underline']
     if fmt['highlight'] and run.font.highlight_color is None:
         run.font.highlight_color = fmt['highlight']

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -13,6 +13,7 @@ from .patterns import (
     UNORDERED_LIST_PATTERN,
     COMMENT_DIRECTIVE_PATTERN,
     CODE_FENCE_PATTERN,
+    ordered_list_is_genuine,
 )
 from .inline_formatting import parse_inline_formatting
 from .block_elements import (
@@ -249,8 +250,11 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
                 if return_element and block_elems:
                     elements.extend(block_elems)
                 return idx, elements
-        # Ordered list
-        if ORDERED_LIST_PATTERN.match(stripped):
+        # Ordered list. A numbered line only starts a list when it begins at 1 or
+        # has a continuation (see ordered_list_is_genuine); otherwise it falls
+        # through to a plain paragraph so a standalone date like "23. června 2026"
+        # is not misread as an ordered list.
+        if ORDERED_LIST_PATTERN.match(stripped) and ordered_list_is_genuine(lines, start_idx):
             return process_list_items(
                 lines, start_idx, doc, is_ordered=True, level=0, return_elements=return_element,
                 number_styles=style_map.list_number, bullet_styles=style_map.list_bullet,

--- a/docx_tools/patterns.py
+++ b/docx_tools/patterns.py
@@ -93,13 +93,55 @@ _BR_RE = re.compile(r'<br\s*/?>', re.IGNORECASE)
 # Utility
 # ---------------------------------------------------------------------------
 
+def ordered_list_is_genuine(lines, idx) -> bool:
+    """Return True if the ordered-list marker at ``lines[idx]`` should start a list.
+
+    A numbered line begins an ordered list only when its number is ``1`` (a list
+    may legitimately have a single item) OR a continuation follows — another
+    sibling ordered item at the same indent, or a more-indented nested list item.
+    This stops a standalone numbered line such as a date ("23. června 2026") from
+    being misread as an ordered list.
+
+    Note: a day-1 date ("1. června 2026") still matches the ``number == 1`` case
+    and must be escaped ("1\\. června 2026") to render as prose; dates on days
+    2–31 are handled automatically here.
+    """
+    raw = lines[idx]
+    match = ORDERED_LIST_CAPTURE_PATTERN.match(raw.strip())
+    if not match:
+        return False
+    if int(match.group(1)) == 1:
+        return True
+    base_indent = len(raw) - len(raw.lstrip())
+    for nxt in lines[idx + 1:]:
+        stripped = nxt.strip()
+        if not stripped:
+            return False  # blank line ends the run before any continuation
+        indent = len(nxt) - len(nxt.lstrip())
+        if indent > base_indent:
+            # A more-indented list item nested under this one is a continuation.
+            return bool(ORDERED_LIST_PATTERN.match(stripped)
+                        or UNORDERED_LIST_PATTERN.match(stripped))
+        if indent == base_indent:
+            return bool(ORDERED_LIST_PATTERN.match(stripped))  # sibling ordered item
+        return False  # dedent ends the run
+    return False
+
+
 def contains_block_markdown(value: str) -> bool:
     """Return True if *value* contains block-level markdown content."""
     from .block_elements import detect_alignment  # deferred to avoid circular
 
-    for line in value.split('\n'):
+    lines = value.split('\n')
+    for idx, line in enumerate(lines):
         stripped = line.strip()
-        if any(p.match(stripped) for p in _BLOCK_PATTERNS):
+        for pattern in _BLOCK_PATTERNS:
+            if not pattern.match(stripped):
+                continue
+            # A lone numbered line (e.g. a date "23. června 2026") is not a list
+            # unless it starts at 1 or has a continuation — keep it inline prose.
+            if pattern is ORDERED_LIST_PATTERN and not ordered_list_is_genuine(lines, idx):
+                continue
             return True
         if detect_alignment(stripped) is not None:
             return True

--- a/tests/test_docx_ordered_list_date.py
+++ b/tests/test_docx_ordered_list_date.py
@@ -1,0 +1,104 @@
+"""Tests for ordered-list vs. date disambiguation.
+
+A standalone numbered line such as a date ("23. června 2026") used to be misread
+as an ordered-list item. ``ordered_list_is_genuine`` now requires a numbered line
+to either start at 1 or have a continuation before it is treated as a list, so
+dates on days 2–31 render as prose automatically. A day-1 date ("1. června 2026")
+is indistinguishable from a one-item list and must be escaped ("1\\. ...").
+"""
+import sys
+from pathlib import Path
+
+from docx import Document
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from docx_tools.markdown_processor import process_markdown_content  # noqa: E402
+from docx_tools.patterns import ordered_list_is_genuine  # noqa: E402
+
+
+def _new_doc_with_default_styles():
+    """Document from the project's default template (carries ``List Number``)."""
+    default = project_root / "default_templates" / "default_docx_template.docx"
+    assert default.exists(), f"Default template missing at {default}"
+    return Document(str(default))
+
+
+def _render(content):
+    """Render *content* into a fresh document and return the new paragraphs."""
+    doc = _new_doc_with_default_styles()
+    start = len(doc.paragraphs)
+    process_markdown_content(doc, content)
+    return doc.paragraphs[start:]
+
+
+def _is_ordered(paragraph):
+    return bool(paragraph.style.name and paragraph.style.name.startswith("List Number"))
+
+
+# --- helper-level tests -----------------------------------------------------
+
+def test_lone_date_is_not_a_list():
+    assert ordered_list_is_genuine(["23. června 2026"], 0) is False
+
+
+def test_lone_non_one_number_is_not_a_list():
+    assert ordered_list_is_genuine(["5. only item"], 0) is False
+
+
+def test_list_starting_at_one_is_genuine():
+    assert ordered_list_is_genuine(["1. only item"], 0) is True
+
+
+def test_non_one_start_with_sibling_is_genuine():
+    assert ordered_list_is_genuine(["5. Fifth", "6. Sixth"], 0) is True
+
+
+def test_non_one_start_with_nested_child_is_genuine():
+    assert ordered_list_is_genuine(["2. parent", "    - child"], 0) is True
+
+
+def test_blank_line_ends_run_before_continuation():
+    assert ordered_list_is_genuine(["5. Fifth", "", "6. Sixth"], 0) is False
+
+
+def test_two_adjacent_dates_are_a_known_limitation():
+    # Two consecutive date-like lines look exactly like a 2-item list; documented
+    # limitation — escape them if they must stay prose.
+    assert ordered_list_is_genuine(["23. června 2026", "24. července 2026"], 0) is True
+
+
+# --- pipeline-level tests ---------------------------------------------------
+
+def test_lone_date_renders_as_paragraph():
+    paras = _render("23. června 2026")
+    assert len(paras) == 1
+    assert not _is_ordered(paras[0])
+    assert paras[0].text == "23. června 2026"
+
+
+def test_list_starting_at_five_still_renders_as_list():
+    paras = _render("5. Fifth\n6. Sixth")
+    assert all(_is_ordered(p) for p in paras)
+    assert [p.text for p in paras] == ["Fifth", "Sixth"]
+
+
+def test_single_item_list_starting_at_one_renders_as_list():
+    paras = _render("1. Only item")
+    assert len(paras) == 1
+    assert _is_ordered(paras[0])
+    assert paras[0].text == "Only item"
+
+
+def test_two_item_list_renders_as_list():
+    paras = _render("1. First\n2. Second")
+    assert all(_is_ordered(p) for p in paras)
+    assert [p.text for p in paras] == ["First", "Second"]
+
+
+def test_escaped_day_one_date_renders_as_paragraph():
+    paras = _render("1\\. června 2026")
+    assert len(paras) == 1
+    assert not _is_ordered(paras[0])
+    assert paras[0].text == "1. června 2026"

--- a/tests/test_docx_placeholder_formatting.py
+++ b/tests/test_docx_placeholder_formatting.py
@@ -1,0 +1,134 @@
+"""Tests for formatting preservation during template placeholder replacement.
+
+``_replace_placeholder_in_paragraph`` rebuilds the paragraph around a placeholder.
+These tests cover two guarantees:
+
+* the formatting of the surrounding inline text (before/after the placeholder) is
+  preserved instead of being flattened to plain runs, and
+* the placeholder run's own bold/italic/underline/highlight (plus font/colour) is
+  captured and applied to the replacement text, without clobbering formatting the
+  markdown value asked for.
+"""
+import sys
+from pathlib import Path
+
+from docx import Document
+from docx.shared import Pt, RGBColor
+from docx.enum.text import WD_COLOR_INDEX
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from docx_tools.dynamic_docx_tools import _replace_placeholder_in_paragraph  # noqa: E402
+
+
+def _run_with_text(paragraph, text):
+    """Return the first run whose text equals *text* (or None)."""
+    return next((r for r in paragraph.runs if r.text == text), None)
+
+
+# --- surrounding inline text keeps its formatting ---------------------------
+
+def test_surrounding_runs_keep_their_formatting():
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("Important: ").bold = True
+    p.add_run("{{val}}")
+    p.add_run(" done").italic = True
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "X", doc=doc)
+
+    assert p.text == "Important: X done"
+    assert _run_with_text(p, "Important: ").bold is True
+    assert _run_with_text(p, " done").italic is True
+
+
+def test_text_after_placeholder_with_color_is_preserved():
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("{{val}}")
+    after = p.add_run(" tail")
+    after.font.color.rgb = RGBColor(0xFF, 0x00, 0x00)
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "head", doc=doc)
+
+    assert p.text == "head tail"
+    assert _run_with_text(p, " tail").font.color.rgb == RGBColor(0xFF, 0x00, 0x00)
+
+
+# --- placeholder's own formatting is applied to the replacement -------------
+
+def test_placeholder_bold_applied_to_replacement():
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("{{val}}").bold = True
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "hello", doc=doc)
+
+    assert p.text == "hello"
+    assert all(r.bold for r in p.runs)
+
+
+def test_placeholder_italic_underline_highlight_applied():
+    doc = Document()
+    p = doc.add_paragraph()
+    run = p.add_run("{{val}}")
+    run.italic = True
+    run.underline = True
+    run.font.highlight_color = WD_COLOR_INDEX.YELLOW
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "hi", doc=doc)
+
+    out = _run_with_text(p, "hi")
+    assert out.italic is True
+    assert out.underline is True
+    assert out.font.highlight_color == WD_COLOR_INDEX.YELLOW
+
+
+def test_placeholder_font_name_and_size_applied():
+    doc = Document()
+    p = doc.add_paragraph()
+    run = p.add_run("{{val}}")
+    run.font.name = "Courier New"
+    run.font.size = Pt(14)
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "hi", doc=doc)
+
+    out = _run_with_text(p, "hi")
+    assert out.font.name == "Courier New"
+    assert out.font.size == Pt(14)
+
+
+# --- markdown formatting in the value is not clobbered ----------------------
+
+def test_value_markdown_combines_with_placeholder_format():
+    # Placeholder is italic; the value asks for bold on part of it. The bold part
+    # must stay bold (markdown) AND gain italic (placeholder) — neither wins out.
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("{{val}}").italic = True
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "**strong**", doc=doc)
+
+    out = _run_with_text(p, "strong")
+    assert out.bold is True      # from the markdown value
+    assert out.italic is True    # filled from the placeholder run
+
+
+# --- placeholder split across runs (as Word often stores it) ----------------
+
+def test_split_placeholder_preserves_bold_and_surrounding():
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("Hi ").bold = True
+    r1 = p.add_run("{{va")
+    r1.italic = True
+    r2 = p.add_run("l}}")
+    r2.italic = True
+    p.add_run("!")
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "there", doc=doc)
+
+    assert p.text == "Hi there!"
+    assert _run_with_text(p, "Hi ").bold is True
+    assert _run_with_text(p, "there").italic is True   # from the (italic) placeholder run

--- a/tests/test_docx_placeholder_formatting.py
+++ b/tests/test_docx_placeholder_formatting.py
@@ -115,6 +115,30 @@ def test_value_markdown_combines_with_placeholder_format():
     assert out.italic is True    # filled from the placeholder run
 
 
+def test_placeholder_explicit_not_bold_is_propagated():
+    # An explicit bold=False on the placeholder (e.g. to counteract a bold
+    # paragraph style) should pass through to a plain replacement value.
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("{{val}}").bold = False
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "hi", doc=doc)
+
+    assert _run_with_text(p, "hi").bold is False
+
+
+def test_value_markdown_bold_wins_over_placeholder_not_bold():
+    # Even when the placeholder is explicitly not-bold, markdown bold in the value
+    # must win (the value's formatting is never overridden).
+    doc = Document()
+    p = doc.add_paragraph()
+    p.add_run("{{val}}").bold = False
+
+    assert _replace_placeholder_in_paragraph(p, "{{val}}", "**strong**", doc=doc)
+
+    assert _run_with_text(p, "strong").bold is True
+
+
 # --- placeholder split across runs (as Word often stores it) ----------------
 
 def test_split_placeholder_preserves_bold_and_surrounding():


### PR DESCRIPTION
## Summary

Two independent DOCX fixes discovered while reviewing list rendering and template behaviour.

### 1. Numbered-list vs. date disambiguation
A standalone numbered line such as a Czech date `23. června 2026` was misread as a one-item ordered list. Detection is now **continuation-aware**: a numbered line starts a list only when it begins at `1` **or** has a continuation (a sibling/nested list item).

| Input | Result |
|---|---|
| `23. června 2026` (lone) | paragraph ✓ |
| `5. Fifth` / `6. Sixth` | list, start 5 preserved ✓ |
| `1. Only item` (lone) | single-item list ✓ |
| `1. června 2026` (day-1, lone) | indistinguishable from a one-item list → escape as `1\. ...` |

The same `ordered_list_is_genuine` check is applied in both the block dispatcher and `contains_block_markdown`, so template placeholder content behaves consistently. Day-1 dates already render correctly when escaped (`1\.`) via the existing backslash-escape path.

### 2. Placeholder replacement preserves formatting
`_replace_placeholder_in_paragraph` previously flattened the surrounding text to plain runs and only carried over the placeholder's font name/size/colour. Now:
- **Surrounding inline text** (before/after the placeholder, in the same paragraph) keeps its run formatting — sliced at the placeholder boundaries with each slice's `<w:rPr>` deep-copied.
- The **placeholder run's bold/italic/underline/highlight** (alongside font/size/colour) is captured and applied to the replacement text, **only where the markdown value left it unset** — so `**bold**` in the value still wins and combines with, rather than is clobbered by, the placeholder's format.

Scope: applies to the inline replacement path; block content (list/heading values) is still inserted as separate paragraphs styled by `style_map`, as before.

## Tests
- `tests/test_docx_ordered_list_date.py` — 12 cases (helper + full pipeline): lone dates, start-at-5 lists, single-item lists, escaped day-1 date, documented two-adjacent-dates limitation.
- `tests/test_docx_placeholder_formatting.py` — 8 cases: surrounding bold/italic/colour preserved, placeholder bold/italic/underline/highlight/font/size applied, markdown-vs-placeholder combination, split-placeholder.
- Full suite: **533 passed**.

## Docs
README updated for both behaviours (numbered-list/date rule + escape, and placeholder formatting preservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)