### PR TITLE
fix(cd): derive image tag from release payload; add arm64 build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: test -n "$RELEASE_TAG" || { echo "::error::release.tag_name is empty"; exit 1; }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -25,17 +33,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract release tag
-        id: meta
-        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
-            georgx22/mcp-office-docs:${{ steps.meta.outputs.version }}
+            georgx22/mcp-office-docs:${{ github.event.release.tag_name }}
             georgx22/mcp-office-docs:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem

The CD pipeline (`Build & Push Docker Image`) failed for the **v3.12** release:

```
ERROR: failed to build: invalid tag "georgx22/mcp-office-docs:": invalid reference format
```

The image tag had nothing after the colon. The version was sourced from `$GITHUB_REF_NAME`, which came back **empty** because the release event resolved to a `master` branch context instead of the `refs/tags/v3.12` tag ref (the run shows `head_branch: master`, vs `head_branch: v3.11` for the working v3.11 run). buildx rejects the empty reference.

Both the original run and a manual re-run failed, so **no v3.12 image was ever pushed** to Docker Hub.

## Changes

- **Tag source:** use `github.event.release.tag_name` (always populated from the release payload, immune to ref-resolution issues and re-runs) instead of `$GITHUB_REF_NAME`. Drops the now-unneeded `Extract release tag` step.
- **Guard:** add a `Validate release tag` step that fails fast with a clear message if the tag is ever empty.
- **Multi-arch:** add `Set up QEMU` + `platforms: linux/amd64,linux/arm64` so the image publishes for both architectures.

## Follow-up

Once merged, publishing a new **v3.13** release will trigger the fixed, multi-arch build & push. (v3.12 never published an image; v3.13 supersedes it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)