### PR TITLE
fix(docx): recognise lists after <br> and continue numbering across headings

### DIFF
--- a/docx_tools/block_elements.py
+++ b/docx_tools/block_elements.py
@@ -165,7 +165,7 @@ def add_table_to_doc(table_data, doc, col_alignments=None, borderless=False,
 # ---------------------------------------------------------------------------
 def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
                        return_elements=False, number_styles=None, bullet_styles=None,
-                       base_indent=None):
+                       base_indent=None, ordered_run=None):
     """Process markdown list items with proper Word numbering.
     When *return_elements* is True the created paragraph XML elements are
     removed from the document body and returned so the caller can re-insert
@@ -205,6 +205,7 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
     num_resolved = False
     current_num_id = None
     items_emitted = 0
+    last_item_number = None  # last top-level ordered number, to extend ordered_run
     while i < n:
         original_line = lines[i]
         stripped_left = original_line.lstrip()
@@ -238,6 +239,7 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
                     )
             if current_num_id is not None:
                 apply_numbering(paragraph, current_num_id, level)
+            last_item_number = item_number
         parse_inline_formatting(item_text, paragraph)
         items_emitted += 1
         if return_elements:
@@ -283,6 +285,10 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
             elements.append(paragraph._p)
             doc._body._body.remove(paragraph._p)
         i = start_idx + 1
+    # Record where this top-level ordered list left off so a later sibling list
+    # (e.g. after a heading) can continue its numbering instead of restarting.
+    if ordered_run is not None and is_ordered and level == 0 and last_item_number is not None:
+        ordered_run['next'] = last_item_number + 1
     return i, elements
 # ---------------------------------------------------------------------------
 # Page break / horizontal line

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -48,7 +48,9 @@ from template_utils import find_file_in_template_dirs
 from async_runner import run_blocking
 from .conditionals import resolve_conditionals
 from .inline_formatting import parse_inline_formatting
-from .patterns import contains_block_markdown, normalize_escaped_newlines
+from .patterns import (
+    contains_block_markdown, normalize_escaped_newlines, expand_br_to_block_breaks,
+)
 from .markdown_processor import process_markdown_content
 from .style_map import DEFAULT_STYLE_MAP, build_style_map
 from fastmcp.exceptions import ToolError
@@ -262,6 +264,11 @@ def _replace_placeholder_in_paragraph(
         # parse_inline_formatting normalise again downstream (idempotent — that is
         # what the base tool relies on), so this early pass is for routing only.
         value = normalize_escaped_newlines(value)
+        # Likewise promote a <br> that borders block content (a list/heading) to a
+        # real newline up front, so contains_block_markdown / the multi-line check
+        # route such values to the block pipeline instead of inline-only (where the
+        # list would render as literal text). Prose <br> is left as a soft break.
+        value = expand_br_to_block_breaks(value)
 
         # Collect all runs and their text
         runs = list(paragraph.runs)

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -10,11 +10,13 @@ from .patterns import (
     IMAGE_PATTERN,
     TABLE_LINE_PATTERN,
     ORDERED_LIST_PATTERN,
+    ORDERED_LIST_CAPTURE_PATTERN,
     UNORDERED_LIST_PATTERN,
     COMMENT_DIRECTIVE_PATTERN,
     CODE_FENCE_PATTERN,
     ordered_list_is_genuine,
     normalize_escaped_newlines,
+    expand_br_to_block_breaks,
 )
 from .inline_formatting import parse_inline_formatting
 from .block_elements import (
@@ -33,6 +35,25 @@ from .style_map import (
     apply_style_to_block_element,
 )
 logger = logging.getLogger(__name__)
+
+
+def _continues_ordered_run(stripped, ordered_run) -> bool:
+    """True if the ordered marker on *stripped* continues the running count.
+
+    *ordered_run* is a ``{'next': int | None}`` cell tracking the number that
+    would continue the most recent top-level ordered list (see
+    :func:`process_markdown_content`). This lets a continuation list resume after
+    an intervening heading/blank line — e.g. items ``1.``/``2.`` under one
+    heading and ``3.``/``4.`` under the next — even though, in isolation, a lone
+    ``3.`` followed by a blank line is indistinguishable from a date and would
+    not pass :func:`ordered_list_is_genuine`.
+    """
+    if not ordered_run or ordered_run.get('next') is None:
+        return False
+    match = ORDERED_LIST_CAPTURE_PATTERN.match(stripped)
+    return bool(match) and int(match.group(1)) == ordered_run['next']
+
+
 def process_markdown_content(doc, content, return_elements=False,
                              style_map=DEFAULT_STYLE_MAP):
     """Process full markdown content with all features: spacing, soft breaks, blocks.
@@ -51,10 +72,20 @@ def process_markdown_content(doc, content, return_elements=False,
     # newlines) as genuine newlines so they split into paragraphs/blocks instead
     # of being mangled into stray "n" characters downstream.
     content = normalize_escaped_newlines(content)
+    # Promote <br> that borders block content (lists/headings) to real newlines
+    # so such blocks are detected; a prose <br> stays an inline soft break.
+    content = expand_br_to_block_breaks(content)
     lines = content.split('\n')
     n = len(lines)
     i = 0
     all_elements = []
+    # Running ordered-list count: the number that would continue the most recent
+    # top-level ordered list. Preserved across headings and blank lines so a list
+    # can resume after a section heading; reset by any other block content. Lets
+    # _continues_ordered_run() accept e.g. "3." after a heading even when it is
+    # blank-separated (and so not locally genuine). A mutable cell so
+    # process_list_items can update it through process_markdown_block.
+    ordered_run = {'next': None}
     while i < n:
         line = lines[i]
         # --- Empty line handling (preserve spacing) ---
@@ -88,20 +119,31 @@ def process_markdown_content(doc, content, return_elements=False,
                 stripped_hashes = first_line.lstrip('#')
                 level = len(first_line) - len(stripped_hashes)
                 elem = _add_heading(doc, level, stripped_hashes.strip(), style_map)._p
+                # A heading does not break ordered-list continuation.
             elif first_line.startswith('>'):
                 elem = _add_quote(doc, full_text[1:].strip(), style_map)._p
+                ordered_run['next'] = None
             else:
                 para = doc.add_paragraph()
                 parse_inline_formatting(full_text, para)
                 elem = para._p
+                ordered_run['next'] = None
             if return_elements:
                 all_elements.append(elem)
                 doc._body._body.remove(elem)
             continue
         # --- All other block elements: delegate to block processor ---
+        # Continuation survives only headings and (above) blank lines; any other
+        # block content breaks the run. A numbered line is left alone so a list
+        # that actually renders can update the count via process_list_items.
+        stripped = line.strip()
+        if (HEADING_PATTERN.match(stripped) is None
+                and ORDERED_LIST_PATTERN.match(stripped) is None):
+            ordered_run['next'] = None
         i, block_elems = process_markdown_block(doc, lines, i,
                                                 return_element=return_elements,
-                                                style_map=style_map)
+                                                style_map=style_map,
+                                                ordered_run=ordered_run)
         if return_elements:
             all_elements.extend(block_elems)
     return all_elements
@@ -164,12 +206,18 @@ def _render_code_block(doc, lines, start_idx, fence_match, style_map, collect):
 
 
 def process_markdown_block(doc, lines, start_idx, return_element=True,
-                           style_map=DEFAULT_STYLE_MAP, directives=None):
+                           style_map=DEFAULT_STYLE_MAP, directives=None,
+                           ordered_run=None):
     """Process a single markdown block element and return created XML elements.
 
     *directives* carries comment-directive options (`borderless`, `widths`, …)
     collected from `<!-- … -->` lines immediately above this block; see the
     directive branch below.
+
+    *ordered_run* is the running ordered-list count cell from
+    :func:`process_markdown_content`; when present it lets a numbered line that
+    continues the previous list (e.g. after a heading) start a list even if it is
+    not locally genuine, and lets the rendered list update the count.
     Returns:
         Tuple of (next_index, list_of_elements).
     """
@@ -259,10 +307,13 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
         # has a continuation (see ordered_list_is_genuine); otherwise it falls
         # through to a plain paragraph so a standalone date like "23. června 2026"
         # is not misread as an ordered list.
-        if ORDERED_LIST_PATTERN.match(stripped) and ordered_list_is_genuine(lines, start_idx):
+        if ORDERED_LIST_PATTERN.match(stripped) and (
+                ordered_list_is_genuine(lines, start_idx)
+                or _continues_ordered_run(stripped, ordered_run)):
             return process_list_items(
                 lines, start_idx, doc, is_ordered=True, level=0, return_elements=return_element,
                 number_styles=style_map.list_number, bullet_styles=style_map.list_bullet,
+                ordered_run=ordered_run,
             )
         # Unordered list
         if UNORDERED_LIST_PATTERN.match(stripped):
@@ -301,7 +352,7 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
             existing = None if return_element else set(body)
             new_idx, block_elems = process_markdown_block(
                 doc, lines, idx, return_element=return_element, style_map=style_map,
-                directives=collected,
+                directives=collected, ordered_run=ordered_run,
             )
             # The 'style' directive applies the named style to whatever was produced.
             style_name = collected.get('style')

--- a/docx_tools/patterns.py
+++ b/docx_tools/patterns.py
@@ -158,6 +158,60 @@ def ordered_list_is_genuine(lines, idx) -> bool:
     return False
 
 
+def _segment_is_block(segments, idx) -> bool:
+    """Return True if ``segments[idx]`` begins a block element.
+
+    A heading or unordered-list marker always counts; an ordered-list marker
+    counts only when :func:`ordered_list_is_genuine` accepts it within the
+    *segments* list (so a lone number that is really a date does not).
+    """
+    seg = segments[idx]
+    if HEADING_PATTERN.match(seg) or UNORDERED_LIST_PATTERN.match(seg):
+        return True
+    return bool(ORDERED_LIST_PATTERN.match(seg)
+                and ordered_list_is_genuine(segments, idx))
+
+
+def expand_br_to_block_breaks(text: str) -> str:
+    """Promote ``<br>`` to a real newline when it borders block content.
+
+    ``<br>`` is normally an *inline* soft line break (see
+    :func:`docx_tools.inline_formatting.parse_inline_formatting`). But the
+    block-level parser splits only on real newlines, so a list or heading that a
+    model separated from surrounding text with ``<br>`` is never recognised — a
+    ``"1. ..."`` after a ``<br>`` would render as literal text instead of a
+    numbered list. This pre-pass splits a physical line on ``<br>`` *only* when
+    one of the resulting segments is itself a block element (a heading, or a
+    genuine ordered/unordered list item); plain-prose ``<br>`` is left untouched
+    so it still renders as a within-paragraph soft break.
+
+    Table rows (``| ... |``) and fenced code blocks are never touched: ``<br>``
+    inside a table cell is an in-cell break handled by ``add_table_to_doc`` and
+    code is taken verbatim. Idempotent — running it on already-expanded text is a
+    no-op, so it is safe to call on both the base and placeholder paths.
+    """
+    if not text or not _BR_RE.search(text):
+        return text
+    out = []
+    in_code = False
+    for line in text.split('\n'):
+        stripped = line.strip()
+        if CODE_FENCE_PATTERN.match(stripped):
+            in_code = not in_code
+            out.append(line)
+            continue
+        if in_code or TABLE_LINE_PATTERN.match(stripped) or not _BR_RE.search(line):
+            out.append(line)
+            continue
+        segments = [seg.strip() for seg in _BR_RE.split(line)]
+        if len(segments) > 1 and any(_segment_is_block(segments, idx)
+                                     for idx in range(len(segments))):
+            out.extend(segments)
+        else:
+            out.append(line)
+    return '\n'.join(out)
+
+
 def contains_block_markdown(value: str) -> bool:
     """Return True if *value* contains block-level markdown content."""
     from .block_elements import detect_alignment  # deferred to avoid circular

--- a/tests/test_docx_list_continuation_and_br.py
+++ b/tests/test_docx_list_continuation_and_br.py
@@ -1,0 +1,209 @@
+"""Tests for two related list-rendering fixes.
+
+1. ``<br>`` bordering block content (a list/heading) is promoted to a real line
+   break so the block is recognised — both in the base markdown pipeline and in
+   the dynamic-template placeholder path. A prose ``<br>`` stays an inline soft
+   break, and a ``<br>`` inside a table cell is untouched.
+
+2. Ordered-list numbering continues across an intervening heading/blank line
+   (e.g. procedural filings whose numbered paragraphs run 1, 2 under one heading
+   and 3, 4 under the next). A running counter remembers where the previous list
+   left off; a lone numbered line with no such predecessor still renders as prose
+   (date disambiguation, see test_docx_ordered_list_date.py).
+
+Numbering is asserted on the underlying XML because Word computes the visible
+numbers at display time; they are not stored as paragraph text.
+"""
+import sys
+from pathlib import Path
+
+from docx import Document
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from docx_tools.markdown_processor import process_markdown_content  # noqa: E402
+from docx_tools.patterns import expand_br_to_block_breaks  # noqa: E402
+from docx_tools.dynamic_docx_tools import (  # noqa: E402
+    _replace_placeholders_in_paragraph,
+)
+
+
+def _new_doc():
+    default = project_root / "default_templates" / "default_docx_template.docx"
+    assert default.exists(), f"Default template missing at {default}"
+    return Document(str(default))
+
+
+def _render(content):
+    doc = _new_doc()
+    start = len(doc.paragraphs)
+    process_markdown_content(doc, content)
+    return doc, doc.paragraphs[start:]
+
+
+def _is_ordered(p):
+    return bool(p.style.name and p.style.name.startswith("List Number"))
+
+
+def _num_id_of(p):
+    vals = p._p.xpath('.//w:numPr/w:numId/@w:val')
+    return vals[0] if vals else None
+
+
+def _start_override(doc, num_id):
+    num = doc.part.numbering_part.element.num_having_numId(int(num_id))
+    vals = num.xpath('./w:lvlOverride[@w:ilvl="0"]/w:startOverride/@w:val')
+    return vals[0] if vals else None
+
+
+# ---------------------------------------------------------------------------
+# expand_br_to_block_breaks (unit)
+# ---------------------------------------------------------------------------
+
+def test_expand_br_splits_when_list_follows():
+    assert expand_br_to_block_breaks("Intro:<br>1. A<br>2. B") == "Intro:\n1. A\n2. B"
+
+
+def test_expand_br_splits_when_heading_follows():
+    assert expand_br_to_block_breaks("Lead<br># Title") == "Lead\n# Title"
+
+
+def test_expand_br_leaves_prose_soft_break_alone():
+    # No block element after the <br>: keep it for the inline soft-break path.
+    assert expand_br_to_block_breaks("Line A<br>Line B") == "Line A<br>Line B"
+
+
+def test_expand_br_ignores_lone_number_that_is_a_date():
+    # "23." after a <br> is not a genuine list (no continuation) -> not split.
+    assert expand_br_to_block_breaks("On<br>23. brezna") == "On<br>23. brezna"
+
+
+def test_expand_br_leaves_table_rows_untouched():
+    table = "| a<br>b | c |"
+    assert expand_br_to_block_breaks(table) == table
+
+
+def test_expand_br_is_idempotent():
+    once = expand_br_to_block_breaks("Intro:<br>1. A<br>2. B")
+    assert expand_br_to_block_breaks(once) == once
+
+
+# ---------------------------------------------------------------------------
+# Fix #1 — <br> before a list (base pipeline)
+# ---------------------------------------------------------------------------
+
+def test_br_separated_list_becomes_numbered_items():
+    doc, paras = _render("Vyrok soudu:<br>1. Prvni<br>2. Druhy<br>3. Treti")
+    intro = [p for p in paras if p.text == "Vyrok soudu:"]
+    items = [p for p in paras if _is_ordered(p)]
+    assert len(intro) == 1 and not _is_ordered(intro[0])
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti"]
+
+
+def test_prose_br_stays_single_soft_break_paragraph():
+    doc, paras = _render("Line A<br>Line B")
+    body = [p for p in paras if p.text.strip()]
+    assert len(body) == 1
+    assert "Line A" in body[0].text and "Line B" in body[0].text
+    # A soft break (<w:br/>), not a new paragraph.
+    assert body[0]._p.xpath('.//w:br')
+
+
+def test_br_inside_table_cell_is_preserved():
+    md = "| H1 | H2 |\n| --- | --- |\n| a<br>b | c |"
+    doc, _ = _render(md)
+    assert len(doc.tables) == 1
+    cell = doc.tables[0].rows[1].cells[0]
+    assert [p.text for p in cell.paragraphs] == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Fix #2 — continuation across a heading
+# ---------------------------------------------------------------------------
+
+def test_numbering_continues_after_heading():
+    md = (
+        "## I. Uvod\n\n"
+        "1. Prvni\n\n"
+        "2. Druhy\n\n"
+        "## II. Argumentace\n\n"
+        "3. Treti\n\n"
+        "4. Ctvrty\n"
+    )
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti", "Ctvrty"]
+
+    first_run = _num_id_of(items[0])
+    second_run = _num_id_of(items[2])
+    assert _num_id_of(items[1]) == first_run
+    assert _num_id_of(items[3]) == second_run
+    assert first_run != second_run, "the continuation is a fresh numbering instance"
+    # The continuation instance resumes the count at 3 via startOverride.
+    assert _start_override(doc, first_run) == "1"
+    assert _start_override(doc, second_run) == "3"
+
+
+def test_single_continuation_item_after_heading_is_a_list():
+    md = "1. Prvni\n\n2. Druhy\n\n## II\n\n3. Treti\n"
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti"]
+    assert _start_override(doc, _num_id_of(items[2])) == "3"
+
+
+def test_new_list_starting_at_one_restarts_after_heading():
+    md = "1. Prvni\n\n2. Druhy\n\n## II\n\n1. Novy\n\n2. Dalsi\n"
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Novy", "Dalsi"]
+    assert _start_override(doc, _num_id_of(items[2])) == "1"
+
+
+def test_prose_between_lists_breaks_continuation():
+    # An ordinary paragraph (not a heading) resets the run, so "3." with no
+    # immediate sibling falls back to prose rather than joining the count.
+    md = "1. Prvni\n\n2. Druhy\n\nNejaky odstavec.\n\n3. Treti\n"
+    doc, paras = _render(md)
+    assert any(p.text == "3. Treti" and not _is_ordered(p) for p in paras)
+
+
+def test_standalone_non_one_pair_blank_separated_stays_prose():
+    # No preceding list -> textually a date pair -> prose (date disambiguation).
+    doc, paras = _render("5. Paty\n\n6. Sesty")
+    assert all(not _is_ordered(p) for p in paras if p.text.strip())
+
+
+def test_non_continuing_number_after_heading_stays_prose():
+    # Continuation must match the running count exactly: after a list ends at 2
+    # (run resumes at 3), a "23." under the next heading does not continue and so
+    # — being blank-separated and not locally genuine — renders as prose.
+    md = "1. Prvni\n\n2. Druhy\n\n## II\n\n23. brezna 2026\n"
+    doc, paras = _render(md)
+    assert any(p.text == "23. brezna 2026" and not _is_ordered(p) for p in paras)
+
+
+# ---------------------------------------------------------------------------
+# Fix #1b — <br> list inside a template placeholder
+# ---------------------------------------------------------------------------
+
+def _render_placeholder(value):
+    doc = _new_doc()
+    p = doc.add_paragraph()
+    p.add_run("{{body}}")
+    _replace_placeholders_in_paragraph(p, {"body": value}, doc=doc)
+    return doc
+
+
+def test_placeholder_br_separated_list_becomes_numbered_items():
+    doc = _render_placeholder("Vyrok:<br>1. Prvni<br>2. Druhy")
+    items = [p for p in doc.paragraphs if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy"]
+    assert any(p.text == "Vyrok:" and not _is_ordered(p) for p in doc.paragraphs)
+
+
+def test_placeholder_real_newline_list_still_works():
+    doc = _render_placeholder("Intro\n1. Prvni\n2. Druhy")
+    items = [p for p in doc.paragraphs if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy"]


### PR DESCRIPTION
## Problem

Two related DOCX list-rendering bugs (plus a placeholder-path variant), reproduced against the real render pipeline:

1. **Numbering after `<br>` is lost.** `<br>` was only ever an *inline* soft break, but the block parser splits only on real newlines — so a `1. …` after a `<br>` rendered as literal text. This also leaked into the **placeholder** path (the router uses `contains_block_markdown` + a "has newline" check, neither of which saw `<br>`).
2. **Numbering continuation after a heading is lost.** A continuing item like `3.`, blank-separated (normal in procedural filings / *procesní podání*), failed the `ordered_list_is_genuine` gate — which deliberately rejects a blank-separated non-`1` number to keep dates (`23.\n\n24.`) out of lists. The numbering engine already honored the start number via `startOverride`; the blocker was purely *detection*.

## Fix

- **`expand_br_to_block_breaks()`** (`patterns.py`): promotes `<br>` to a real newline **only** when a resulting segment is a genuine block (heading / list item). Prose `<br>` stays a soft break; table rows and code fences are untouched; idempotent. Applied in `process_markdown_content` (base tool) and in the placeholder router (`dynamic_docx_tools.py`).
- **Running ordered counter** (`markdown_processor.py` + `block_elements.py`): tracks where the most recent top-level ordered list left off, preserved across headings + blank lines and reset by other content. A numbered line that matches the running count starts a list and resumes via the existing `startOverride`. `ordered_list_is_genuine` stays pure/local, so a lone blank-separated number with no predecessor still renders as prose (date disambiguation preserved — no existing behaviour changed).

## Behaviour

`Výrok soudu:<br>1. První<br>2. Druhý` → `Výrok soudu:` paragraph + numbered list **1, 2** (base **and** placeholder).

```
## I. Úvod
1. První
2. Druhý
## II. Argumentace
3. Třetí
4. Čtvrtý
```
→ a single visual sequence **1, 2, 3, 4** (continuation is a fresh numbering instance with `startOverride=3`). A single continuing item after a heading also works. A `1.` restart still restarts.

**Preserved (tested):** prose `Line A<br>Line B` stays one soft-break paragraph; `<br>` in table cells stays in-cell; standalone dates / blank-separated `5.`/`6.` with no preceding list stay prose.

**Known limitation (intentional, unchanged):** a placeholder value that is, *in isolation*, a blank-separated list starting at a non-`1` number is textually identical to a date pair and stays prose; the same value without blanks, or with a preceding `1./2.`, renders as a list.

## Tests

Adds `tests/test_docx_list_continuation_and_br.py` (17 tests). Full docx suite: **337 passing**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)