### PR TITLE
fix(auth): surface Authorization header for API-key middleware

### DIFF
--- a/middleware.py
+++ b/middleware.py
@@ -83,13 +83,10 @@ class ApiKeyAuthMiddleware(Middleware):
     # Middleware hook
     # ------------------------------------------------------------------
     async def on_request(self, context: MiddlewareContext, call_next):
-        # NOTE: get_http_headers() strips a set of "problematic" headers by
-        # default — and that set INCLUDES `authorization` (and
-        # `proxy-authorization`). Without opting them back in via `include=`,
-        # an `Authorization: Bearer <key>` request arrives here with the header
-        # already removed, so only `x-api-key` would ever authenticate. Pass
-        # include={...} so the Authorization header is surfaced to us.
-        headers = get_http_headers(include={"authorization", "proxy-authorization"}) or {}
+        # get_http_headers() strips "authorization" by default; include= opts it
+        # back in so both Bearer and plain-token Authorization requests can
+        # authenticate (without this, only x-api-key would ever be seen).
+        headers = get_http_headers(include={"authorization"}) or {}
         api_key = self._extract_key(headers)
 
         if api_key is None or not secrets.compare_digest(api_key, self.expected_key):

--- a/middleware.py
+++ b/middleware.py
@@ -83,7 +83,13 @@ class ApiKeyAuthMiddleware(Middleware):
     # Middleware hook
     # ------------------------------------------------------------------
     async def on_request(self, context: MiddlewareContext, call_next):
-        headers = get_http_headers() or {}
+        # NOTE: get_http_headers() strips a set of "problematic" headers by
+        # default — and that set INCLUDES `authorization` (and
+        # `proxy-authorization`). Without opting them back in via `include=`,
+        # an `Authorization: Bearer <key>` request arrives here with the header
+        # already removed, so only `x-api-key` would ever authenticate. Pass
+        # include={...} so the Authorization header is surfaced to us.
+        headers = get_http_headers(include={"authorization", "proxy-authorization"}) or {}
         api_key = self._extract_key(headers)
 
         if api_key is None or not secrets.compare_digest(api_key, self.expected_key):

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -130,6 +130,47 @@ def _make_context(method: str = "tools/call"):
     return ctx
 
 
+class TestAuthorizationHeaderSurfaced:
+    """Regression: FastMCP's get_http_headers() strips `authorization` by default.
+
+    These use the REAL get_http_headers (only the underlying request is faked),
+    so they would fail if on_request stopped opting the header back in.
+    """
+
+    async def test_real_get_http_headers_surfaces_authorization(self):
+        import fastmcp.server.dependencies as deps
+        from starlette.datastructures import Headers
+
+        fake_request = MagicMock()
+        fake_request.headers = Headers({"Authorization": "Bearer secret-123", "host": "x"})
+
+        mw = ApiKeyAuthMiddleware("secret-123")
+        call_next = AsyncMock(return_value="ok")
+        context = _make_context()
+
+        # Patch only the request lookup; get_http_headers runs for real and
+        # would strip Authorization unless on_request passes include=.
+        with patch.object(deps, "get_http_request", return_value=fake_request):
+            result = await mw.on_request(context, call_next)
+
+        call_next.assert_awaited_once_with(context)
+        assert result == "ok"
+
+    async def test_on_request_opts_in_authorization_header(self):
+        """on_request must ask get_http_headers to include the auth headers."""
+        mw = ApiKeyAuthMiddleware("secret-123")
+        call_next = AsyncMock(return_value="ok")
+        context = _make_context()
+
+        with patch("middleware.get_http_headers",
+                   return_value={"authorization": "Bearer secret-123"}) as ghh:
+            await mw.on_request(context, call_next)
+
+        _args, kwargs = ghh.call_args
+        included = {h.lower() for h in (kwargs.get("include") or set())}
+        assert "authorization" in included
+
+
 class TestOnRequest:
     """Integration-style tests for the on_request middleware hook."""
 

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -148,8 +148,10 @@ class TestAuthorizationHeaderSurfaced:
         call_next = AsyncMock(return_value="ok")
         context = _make_context()
 
-        # Patch only the request lookup; get_http_headers runs for real and
-        # would strip Authorization unless on_request passes include=.
+        # Patch only FastMCP's internal request accessor so the real
+        # get_http_headers runs (it would strip Authorization unless on_request
+        # passes include=). If this breaks after a FastMCP upgrade, check
+        # fastmcp.server.dependencies.get_http_request.
         with patch.object(deps, "get_http_request", return_value=fake_request):
             result = await mw.on_request(context, call_next)
 


### PR DESCRIPTION
## Problem

A correctly configured `API_KEY` was rejected when the client authenticated with the **`Authorization`** header (`Bearer <key>` or plain). Only `x-api-key` worked.

## Root cause

FastMCP's `get_http_headers()` strips a set of "problematic" headers **by default**, and that set includes **`authorization`** (and `proxy-authorization`). The middleware called it bare:

```python
headers = get_http_headers() or {}   # Authorization already removed here
```

so the `Authorization` header was gone before `_extract_key()` ran. Demonstrated directly against the installed FastMCP:

```
OLD (default)   get_http_headers() -> {}                                  # authorization stripped
NEW (include=)  get_http_headers(include={"authorization", ...}) -> {"authorization": "Bearer secret-123"}
```

## Fix

```python
headers = get_http_headers(include={"authorization", "proxy-authorization"}) or {}
```

The `include=` parameter removes those names from the exclusion set so the header reaches the middleware. `x-api-key` was never excluded and keeps working.

## Why existing tests missed it

Every `on_request` test mocked `get_http_headers` to return the header dict directly, masking the real stripping. This PR adds regression tests that:
- run the **real** `get_http_headers` (faking only the underlying request) and assert an `Authorization: Bearer` request authenticates; and
- assert `on_request` opts `authorization` into the `include` set.

Both fail on the old code and pass with the fix.

## Testing
- **638 passed** (full suite; the one deselected test is the pre-existing network-only pptx image test).
- `ruff check .` clean.

## Risk
- Tiny, self-contained change to `middleware.py`. No behaviour change for `x-api-key`; restores intended behaviour for `Authorization`. Auth is still disabled entirely when `API_KEY` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6T73vVGLZjUQ8dJ2bXkLF)_