### PR TITLE
fix(docx): preserve <center>/<div align> alignment under placeholder layout inheritance

### DIFF
--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -196,11 +196,9 @@ def _propagate_format_to_block(doc, inserted, src_ppr, fmt) -> None:
         if ppr is not None and ppr.find(qn('w:pStyle')) is not None:
             continue
         if layout_ppr is not None:
-            # An explicit alignment the markdown set on this otherwise-plain prose
-            # (e.g. via <center> or <div align="...">) is deliberate, so it must
-            # survive the layout inheritance instead of being clobbered by the
-            # placeholder's own alignment. Capture it before swapping the pPr and
-            # re-apply afterwards (via the API, so <w:jc> lands in schema order).
+            # Preserve a deliberate markdown alignment (e.g. <center>, <div align>)
+            # across the pPr swap so it wins over the placeholder's own alignment;
+            # re-apply via the API so <w:jc> lands in schema order.
             own_alignment = para.alignment
             if ppr is not None:
                 elem.remove(ppr)

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -190,15 +190,24 @@ def _propagate_format_to_block(doc, inserted, src_ppr, fmt) -> None:
     for elem in inserted:
         if elem.tag != qn('w:p'):
             continue  # tables etc. are not styled here
+        para = Paragraph(elem, doc._body)
         ppr = elem.find(qn('w:pPr'))
         # An explicit paragraph style means the markdown set the look on purpose.
         if ppr is not None and ppr.find(qn('w:pStyle')) is not None:
             continue
         if layout_ppr is not None:
+            # An explicit alignment the markdown set on this otherwise-plain prose
+            # (e.g. via <center> or <div align="...">) is deliberate, so it must
+            # survive the layout inheritance instead of being clobbered by the
+            # placeholder's own alignment. Capture it before swapping the pPr and
+            # re-apply afterwards (via the API, so <w:jc> lands in schema order).
+            own_alignment = para.alignment
             if ppr is not None:
                 elem.remove(ppr)
             elem.insert(0, copy.deepcopy(layout_ppr))  # pPr must be the paragraph's first child
-        for run in Paragraph(elem, doc._body).runs:
+            if own_alignment is not None:
+                para.alignment = own_alignment
+        for run in para.runs:
             _apply_placeholder_format(run, fmt)
 
 

--- a/tests/test_docx_templates.py
+++ b/tests/test_docx_templates.py
@@ -362,10 +362,10 @@ class TestAlignmentDirectivesInPlaceholders:
         only set spacing (which still produces a <w:pPr> to inherit)."""
         doc = self._replace(
             lambda p: setattr(p.paragraph_format, "space_after", Pt(6)),
-            '<div align="right">\nDate: 2026-06-29\n</div>',
+            '<div align="right">\nRight-aligned text\n</div>',
         )
         result = self._aligned_text(doc)
-        assert ("Date: 2026-06-29", WD_ALIGN_PARAGRAPH.RIGHT) in result
+        assert ("Right-aligned text", WD_ALIGN_PARAGRAPH.RIGHT) in result
 
     def test_center_value_with_following_prose_inherits_placeholder(self):
         """The centered block keeps CENTER while plain prose after it still

--- a/tests/test_docx_templates.py
+++ b/tests/test_docx_templates.py
@@ -327,6 +327,59 @@ class TestMarkdownFormatting:
 
 
 # =============================================================================
+# Alignment Directive Tests
+# =============================================================================
+
+class TestAlignmentDirectivesInPlaceholders:
+    """Alignment set in a value via <center>/<div align="..."> must survive the
+    placeholder-layout inheritance, even when the placeholder paragraph carries
+    its own paragraph properties (alignment/indent/spacing)."""
+
+    def _replace(self, placeholder_setup, value):
+        """Build a doc whose placeholder paragraph is configured by
+        *placeholder_setup*, replace ``{{body}}`` with *value*, return the doc."""
+        doc = Document()
+        para = doc.add_paragraph()
+        placeholder_setup(para)
+        para.add_run("{{body}}")
+        _replace_placeholders_in_document(doc, {"body": value})
+        return doc
+
+    def _aligned_text(self, doc):
+        return [(p.text, p.alignment) for p in doc.paragraphs if p.text.strip()]
+
+    def test_center_block_survives_left_placeholder(self):
+        """<center> wins over a placeholder paragraph explicitly left-aligned."""
+        doc = self._replace(
+            lambda p: setattr(p, "alignment", WD_ALIGN_PARAGRAPH.LEFT),
+            "<center>\nCentered line\n</center>",
+        )
+        result = self._aligned_text(doc)
+        assert ("Centered line", WD_ALIGN_PARAGRAPH.CENTER) in result
+
+    def test_div_right_survives_placeholder_with_spacing(self):
+        """<div align="right"> keeps RIGHT even though the placeholder paragraph
+        only set spacing (which still produces a <w:pPr> to inherit)."""
+        doc = self._replace(
+            lambda p: setattr(p.paragraph_format, "space_after", Pt(6)),
+            '<div align="right">\nDate: 2026-06-29\n</div>',
+        )
+        result = self._aligned_text(doc)
+        assert ("Date: 2026-06-29", WD_ALIGN_PARAGRAPH.RIGHT) in result
+
+    def test_center_value_with_following_prose_inherits_placeholder(self):
+        """The centered block keeps CENTER while plain prose after it still
+        inherits the placeholder paragraph's alignment (the layout feature)."""
+        doc = self._replace(
+            lambda p: setattr(p, "alignment", WD_ALIGN_PARAGRAPH.JUSTIFY),
+            "<center>Centered title</center>\nNormal body paragraph",
+        )
+        result = dict(self._aligned_text(doc))
+        assert result["Centered title"] == WD_ALIGN_PARAGRAPH.CENTER
+        assert result["Normal body paragraph"] == WD_ALIGN_PARAGRAPH.JUSTIFY
+
+
+# =============================================================================
 # Table Placeholder Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Alignment set in a placeholder value via `<center>` or `<div align="...">` was being lost when rendered through a template — specifically whenever the template's placeholder paragraph carried its own paragraph properties (an explicit alignment, or even just paragraph spacing).

## Root cause

The recent "propagate placeholder layout (alignment/indent/spacing)" change (`d44bd8c` / `f9da538`) added `_propagate_format_to_block`, which makes plain prose inserted at a placeholder inherit the placeholder paragraph's layout (e.g. a justified letter body stays justified). It does this by removing each produced paragraph's whole `<w:pPr>` and stamping the placeholder's layout over it.

The guard that protects deliberately-styled paragraphs only checked for a `<w:pStyle>` (headings, lists, quotes). A `<center>` / `<div align="...">` block is plain-styled prose carrying only a `<w:jc>` (alignment) and **no** `<w:pStyle>`, so it slipped through the guard and had its alignment clobbered by the placeholder's own alignment.

Observed before the fix (driving the real placeholder-replacement path):

| Value | Placeholder paragraph | Rendered (before) | Expected |
|---|---|---|---|
| `<center>…</center>` | left-aligned | LEFT ❌ | CENTER |
| `<div align="right">…</div>` | spacing only | default ❌ | RIGHT |
| `<center>…</center>` | justified | JUSTIFY ❌ | CENTER |

When the placeholder paragraph had no `<w:pPr>` at all, alignment survived — which is why the existing tests (built on bare paragraphs) didn't catch it.

## Fix

In `_propagate_format_to_block`, capture an explicit alignment on the produced paragraph before swapping its `<w:pPr>`, and re-apply it afterward via the python-docx API (so `<w:jc>` lands in valid schema order). A deliberate markdown alignment now wins, while plain prose still inherits the placeholder's layout — both behaviors coexist (a centered block stays CENTER, and a following plain line still inherits the placeholder's JUSTIFY).

## Tests

- Added `TestAlignmentDirectivesInPlaceholders` covering the three cases above, including the coexistence case (aligned block keeps its alignment, following prose inherits the placeholder layout).
- Full docx suites pass: **208 passed** (205 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnTcVGF5wmxPPqdi63QP4s)_