### PR TITLE
feat(transport): env-configurable stateless streamable-http (default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,21 @@ RUN_BLOCKING_BY_ASYNCIO_THREAD_ENABLED=
 # executor instead of fanning out and starving each other.
 RUN_BLOCKING_MAX_WORKERS=
 
+# --- Streamable-HTTP session mode ---
+# Default (empty / "false" / "0" / "no" / "off"): STATEFUL.
+#   Each MCP client gets an Mcp-Session-Id minted by the server and that
+#   session lives in this pod's memory. All follow-up requests for that
+#   session MUST land on the same pod. Single-replica deployments only.
+#
+# Truthy ("1" / "true" / "yes" / "on"): STATELESS.
+#   No Mcp-Session-Id lookup is performed; every request is independent.
+#   Required when running with >=2 replicas in EKS which makes it scalable 
+#   horizontally
+#
+# Example:
+#   STATELESS_HTTP=true
+STATELESS_HTTP=
+
 # --- Storage / Upload strategy ---
 # One of: LOCAL, S3, GCS, AZURE
 UPLOAD_STRATEGY=LOCAL

--- a/admin/app.py
+++ b/admin/app.py
@@ -984,7 +984,7 @@ def build_combined_app(mcp, config: Config):
     """
     from starlette.applications import Starlette
 
-    mcp_app = mcp.http_app(path="/mcp")
+    mcp_app = mcp.http_app(path="/mcp", stateless_http=config.stateless_http)
     admin_app = build_admin_app(mcp, config)
     routes = [
         Mount(config.admin.path, app=admin_app),

--- a/config.py
+++ b/config.py
@@ -322,6 +322,21 @@ class Config(BaseModel):
             "RUN_BLOCKING_MAX_WORKERS environment variable."
         ),
     )
+    stateless_http: bool = Field(
+        default=False,
+        description=(
+            "When True, the FastMCP streamable-http transport runs in "
+            "stateless mode: each request is independent, no Mcp-Session-Id "
+            "is tracked, and any pod can serve any follow-up call. Required "
+            "for horizontally-scaled EKS deployments (replicas >= 2) where "
+            "the default in-process session dict would otherwise cause "
+            "-32600 'Session not found' errors when the initialize and "
+            "tools/call requests land on different pods. Default False "
+            "preserves the stateful behaviour; this is safe for single-pod "
+            "deployments and is what every existing deployment uses today. "
+            "Toggled via the STATELESS_HTTP environment variable."
+        ),
+    )
 
     @property
     def admin_password_effective(self) -> Optional[str]:
@@ -439,6 +454,11 @@ class Config(BaseModel):
         except (ValueError, TypeError):
             run_blocking_max_workers = 4
 
+        # Stateless streamable-http transport. Absent or empty env var
+        # means False (existing behaviour). Truthy ("1"/"true"/"yes"/"on")
+        # enables stateless mode for horizontal scaling.
+        stateless_http = cls._parse_bool(os.environ.get("STATELESS_HTTP"))
+
         try:
             return cls(
                 logging=logging_settings,
@@ -447,6 +467,7 @@ class Config(BaseModel):
                 admin=admin_settings,
                 run_blocking_by_asyncio_thread_enabled=run_blocking_by_asyncio_thread_enabled,
                 run_blocking_max_workers=run_blocking_max_workers,
+                stateless_http=stateless_http,
             )
         except ValidationError as e:
             # Wrap Pydantic validation errors in a simpler exception for callers

--- a/main.py
+++ b/main.py
@@ -385,5 +385,6 @@ if __name__ == "__main__":
             host="0.0.0.0",
             port=8958,
             log_level=config.logging.mcp_level_str,
-            path="/mcp"
+            path="/mcp",
+            stateless_http=config.stateless_http,
         )


### PR DESCRIPTION
Adds STATELESS_HTTP env flag (default unset → stateful). When set truthy ("1"/"true"/"yes"/"on"), FastMCP runs streamable-http in stateless mode: each request is independent, no Mcp-Session-Id lookup is performed, and any pod can serve any follow-up call. This is required to scale office-docs horizontally on EKS (replicas >= 2)

Default remains False so every existing deployment is unaffected. Both launch paths honor the flag: mcp.run() (admin-off) forwards via transport_kwargs to run_http_async(stateless_http=...), and the admin-mounted ASGI path passes it directly to mcp.http_app().

Verified against fastmcp==3.4.2: mcp.http_app(stateless_http=False/True) both succeed; mcp.run_http_async source confirms stateless_http forwarding. Existing tests untouched.