### PR TITLE
fix(docx): recognise headings/lists inside <center>/<div align> blocks

### DIFF
--- a/docx_tools/block_elements.py
+++ b/docx_tools/block_elements.py
@@ -12,7 +12,6 @@ from .patterns import (
     UNORDERED_LIST_CAPTURE_PATTERN,
     _ALIGN_INLINE_RE,
     _ALIGN_OPEN_RE,
-    _ALIGN_CLOSE_RE,
 )
 from .inline_formatting import parse_inline_formatting
 from .patterns import _BR_RE
@@ -349,25 +348,7 @@ def detect_alignment(line):
         align = ALIGNMENT_MAP.get((m.group(1) or 'center').lower(), WD_ALIGN_PARAGRAPH.CENTER)
         return None, align
     return None
-
-
-def process_alignment_block(lines, start_idx, doc, alignment, return_elements=False):
-    """Process lines inside a multi-line alignment block."""
-    elements = [] if return_elements else None
-    i = start_idx
-    while i < len(lines):
-        stripped = lines[i].strip()
-        if _ALIGN_CLOSE_RE.match(stripped):
-            i += 1
-            break
-        if not stripped:
-            i += 1
-            continue
-        para = doc.add_paragraph()
-        para.alignment = alignment
-        parse_inline_formatting(stripped, para)
-        if return_elements:
-            elements.append(para._p)
-            doc._body._body.remove(para._p)
-        i += 1
-    return i, elements
+# Multi-line alignment blocks are rendered by
+# markdown_processor._process_alignment_block, which routes the inner lines
+# through the full block pipeline so headings/lists inside <center>/<div align>
+# are recognised (not emitted as literal text) and then applies the alignment.

--- a/docx_tools/block_elements.py
+++ b/docx_tools/block_elements.py
@@ -348,7 +348,3 @@ def detect_alignment(line):
         align = ALIGNMENT_MAP.get((m.group(1) or 'center').lower(), WD_ALIGN_PARAGRAPH.CENTER)
         return None, align
     return None
-# Multi-line alignment blocks are rendered by
-# markdown_processor._process_alignment_block, which routes the inner lines
-# through the full block pipeline so headings/lists inside <center>/<div align>
-# are recognised (not emitted as literal text) and then applies the alignment.

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -3,6 +3,8 @@ This module contains process_markdown_content and process_markdown_block which
 orchestrate all block-level and inline parsing into a python-docx Document.
 """
 import logging
+from docx.oxml.ns import qn
+from docx.text.paragraph import Paragraph
 from .patterns import (
     HEADING_PATTERN,
     PAGE_BREAK_PATTERN,
@@ -14,6 +16,7 @@ from .patterns import (
     UNORDERED_LIST_PATTERN,
     COMMENT_DIRECTIVE_PATTERN,
     CODE_FENCE_PATTERN,
+    _ALIGN_CLOSE_RE,
     ordered_list_is_genuine,
     normalize_escaped_newlines,
     expand_br_to_block_breaks,
@@ -26,7 +29,6 @@ from .block_elements import (
     add_horizontal_line,
     add_image_to_doc,
     detect_alignment,
-    process_alignment_block,
 )
 from .style_map import (
     DEFAULT_STYLE_MAP,
@@ -291,18 +293,29 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
         if align_result is not None:
             inner, alignment = align_result
             if inner is not None:
-                para = doc.add_paragraph()
+                # Inline form: <center>text</center> / <div align="...">text</div>.
+                # A heading written inside it still becomes a real heading (then
+                # aligned), rather than rendering its "#" marks as literal text.
+                heading_match = HEADING_PATTERN.match(inner)
+                if heading_match:
+                    para = _add_heading(doc, len(heading_match.group(1)),
+                                        heading_match.group(2), style_map)
+                else:
+                    para = doc.add_paragraph()
+                    parse_inline_formatting(inner, para)
                 para.alignment = alignment
-                parse_inline_formatting(inner, para)
                 _collect(para._p)
                 return start_idx + 1, elements
-            else:
-                idx, block_elems = process_alignment_block(
-                    lines, start_idx + 1, doc, alignment, return_elements=return_element
-                )
-                if return_element and block_elems:
-                    elements.extend(block_elems)
-                return idx, elements
+            # Block-open form: render the inner lines through the full block
+            # pipeline so headings/lists inside the block are recognised, then
+            # stamp the alignment on every produced paragraph.
+            idx, block_elems = _process_alignment_block(
+                doc, lines, start_idx + 1, alignment, style_map,
+                return_element, ordered_run,
+            )
+            if return_element and block_elems:
+                elements.extend(block_elems)
+            return idx, elements
         # Ordered list. A numbered line only starts a list when it begins at 1 or
         # has a continuation (see ordered_list_is_genuine); otherwise it falls
         # through to a plain paragraph so a standalone date like "23. června 2026"
@@ -375,3 +388,42 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
     except Exception as e:
         logger.error("Failed to process markdown block at line %d: %s", start_idx, e, exc_info=True)
         return start_idx + 1, elements
+
+
+def _process_alignment_block(doc, lines, start_idx, alignment, style_map,
+                             return_element, ordered_run):
+    """Render the lines inside a multi-line ``<center>``/``<div align>`` block.
+
+    Each inner line goes through the normal block pipeline (so headings, lists,
+    tables, etc. are recognised instead of rendering their markers as literal
+    text), and *alignment* is then applied to every produced paragraph.
+
+    Returns ``(next_index, produced_elements)``. ``produced_elements`` is
+    populated only when *return_element* is True (the block pipeline detaches the
+    elements for the caller); otherwise the produced paragraphs stay in the body
+    and are located via a before/after snapshot so the alignment can be stamped.
+    """
+    body = doc._body._body
+    existing = None if return_element else set(body)
+    collected = []
+    i = start_idx
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if _ALIGN_CLOSE_RE.match(stripped):
+            i += 1
+            break
+        if not stripped:
+            i += 1
+            continue
+        i, produced = process_markdown_block(
+            doc, lines, i, return_element=return_element,
+            style_map=style_map, ordered_run=ordered_run,
+        )
+        if return_element:
+            collected.extend(produced)
+    produced_all = (collected if return_element
+                    else [el for el in body if el not in existing])
+    for el in produced_all:
+        if el.tag == qn('w:p'):  # alignment applies to paragraphs, not tables
+            Paragraph(el, doc._body).alignment = alignment
+    return i, collected

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -296,6 +296,9 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
                 # Inline form: <center>text</center> / <div align="...">text</div>.
                 # A heading written inside it still becomes a real heading (then
                 # aligned), rather than rendering its "#" marks as literal text.
+                # Only headings are promoted here; a single-line list such as
+                # "<center>- item</center>" stays inline prose — use the multi-line
+                # block form (handled by _process_alignment_block) for lists.
                 heading_match = HEADING_PATTERN.match(inner)
                 if heading_match:
                     para = _add_heading(doc, len(heading_match.group(1)),

--- a/tests/test_docx_base.py
+++ b/tests/test_docx_base.py
@@ -1713,6 +1713,48 @@ class TestTextAlignment:
                             and p.text.strip()]
         assert len(right_paragraphs) >= 2
 
+    def test_heading_inside_center_block(self):
+        """A heading inside a <center> block is a real heading (aligned), not
+        literal '#' text."""
+        markdown = "<center>\n# Centered Title\n</center>"
+        doc = save_test_document(markdown, "align_heading_center.docx")
+        match = [p for p in doc.paragraphs if p.text.strip() == "Centered Title"]
+        assert match, "heading text should not carry literal '#' marks"
+        assert match[0].style.name == "Heading 1"
+        assert match[0].alignment == WD_ALIGN_PARAGRAPH.CENTER
+
+    def test_heading_inside_div_right_block(self):
+        """A heading inside a <div align="right"> block keeps its style and the
+        block's alignment."""
+        markdown = '<div align="right">\n## Right Heading\n</div>'
+        doc = save_test_document(markdown, "align_heading_right.docx")
+        match = [p for p in doc.paragraphs if p.text.strip() == "Right Heading"]
+        assert match
+        assert match[0].style.name == "Heading 2"
+        assert match[0].alignment == WD_ALIGN_PARAGRAPH.RIGHT
+
+    def test_inline_center_wrapping_heading(self):
+        """The single-line form <center># Heading</center> also yields a real
+        heading rather than literal text."""
+        markdown = "<center># Inline Heading</center>"
+        doc = save_test_document(markdown, "align_heading_inline.docx")
+        match = [p for p in doc.paragraphs if p.text.strip() == "Inline Heading"]
+        assert match
+        assert match[0].style.name == "Heading 1"
+        assert match[0].alignment == WD_ALIGN_PARAGRAPH.CENTER
+
+    def test_list_inside_center_block(self):
+        """List items inside an alignment block are real list paragraphs, aligned
+        — the '#'/'-' markers are not emitted as literal text."""
+        markdown = "<center>\n- one\n- two\n</center>"
+        doc = save_test_document(markdown, "align_list_center.docx")
+        items = [p for p in doc.paragraphs
+                 if p.text.strip() in ("one", "two")]
+        assert len(items) == 2
+        for p in items:
+            assert "Bullet" in p.style.name
+            assert p.alignment == WD_ALIGN_PARAGRAPH.CENTER
+
 
 # =============================================================================
 # Document Metadata Tests (Feature 5)

--- a/tests/test_docx_templates.py
+++ b/tests/test_docx_templates.py
@@ -378,6 +378,24 @@ class TestAlignmentDirectivesInPlaceholders:
         assert result["Centered title"] == WD_ALIGN_PARAGRAPH.CENTER
         assert result["Normal body paragraph"] == WD_ALIGN_PARAGRAPH.JUSTIFY
 
+    def test_heading_inside_center_block_renders_as_heading(self):
+        """A heading inside a <center> block in placeholder content becomes a
+        real heading (aligned), not literal '#' text."""
+        doc = self._replace(lambda p: None, "<center>\n# Centered Heading\n</center>")
+        match = [p for p in doc.paragraphs if p.text.strip() == "Centered Heading"]
+        assert match, "the '#' marks must not leak as literal text"
+        assert match[0].style.name == "Heading 1"
+        assert match[0].alignment == WD_ALIGN_PARAGRAPH.CENTER
+
+    def test_heading_inside_div_right_block_renders_as_heading(self):
+        """A heading inside a <div align="right"> block keeps its style and the
+        block's alignment."""
+        doc = self._replace(lambda p: None, '<div align="right">\n## Right Heading\n</div>')
+        match = [p for p in doc.paragraphs if p.text.strip() == "Right Heading"]
+        assert match
+        assert match[0].style.name == "Heading 2"
+        assert match[0].alignment == WD_ALIGN_PARAGRAPH.RIGHT
+
 
 # =============================================================================
 # Table Placeholder Tests


### PR DESCRIPTION
## Summary

A heading (or list) placed **inside** a multi-line `<center>` or `<div align="...">` block — or written inline as `<center># Heading</center>` — was rendered with its markdown markers as **literal text** (e.g. a literal `# Centered Heading` instead of a centered Heading 1).

## Root cause

The multi-line alignment-block renderer (`process_alignment_block`) ran **inline formatting only** on each inner line; it never checked for headings, lists, or any block markdown. So `#` / `-` markers inside the block were emitted verbatim. This is a longstanding limitation dating to the original block-markdown feature (`68ea0bf`), not a regression from the recent alignment/newline work.

Observed before the fix (both the base markdown tool and template placeholders):

| Input | Before | After |
|---|---|---|
| `<center>` … `# Title` … `</center>` | literal `# Title` ❌ | Heading 1, centered ✅ |
| `<div align="right">` … `## H` … `</div>` | literal `## H` ❌ | Heading 2, right ✅ |
| `<center># Title</center>` (inline) | literal ❌ | Heading 1, centered ✅ |
| List items inside a block | literal `- item` ❌ | aligned list paragraphs ✅ |
| Heading before/after a block | already worked ✅ | still works ✅ |

## Fix

- Route the alignment block's inner lines through the **full block pipeline** (`process_markdown_block`) so headings, lists, tables, etc. are recognised, then stamp the block's alignment on every produced paragraph.
- The inline `<center>…</center>` form likewise promotes a wrapped heading to a real heading.
- Removed the now-obsolete `process_alignment_block` (and its `_ALIGN_CLOSE_RE` import in `block_elements.py`); the logic now lives in `markdown_processor._process_alignment_block`, where the block pipeline is available.

### Precedence

The block alignment is applied as **direct paragraph formatting** (`<w:jc>`), which correctly overrides any alignment defined by the heading's paragraph *style*. A heading wrapped in `<center>` centers regardless of what `Heading 1` defines; a **bare** heading (no wrapper) gets no direct `<w:jc>` and still follows its style. Headings outside an alignment block are untouched.

## Tests

- Base tool (`test_docx_base.py`): headings inside center/right blocks, inline-wrapped heading, and a list inside a center block.
- Template path (`test_docx_templates.py`): heading inside center and div-right placeholder content.
- Full docx suites pass: **214 passed** (208 prior + 6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnTcVGF5wmxPPqdi63QP4s)_