### PR TITLE
Emit flat schemas for optional dynamic-tool args so descriptions survive

### DIFF
--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -690,10 +690,16 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any],
         # Handle regular types
         py_type = TYPE_MAP.get(str(arg.get("type", "string")).lower(), str)
         required = bool(arg.get("required", True))
-        field_type = py_type if required else Optional[py_type]  # type: ignore[index]
         default = arg.get("default", (... if required else None))
         desc = arg.get("description", "")
-        fields[arg_name] = (field_type, Field(default, description=desc) if desc else default)
+        # Always use the plain type — never Optional[...]. Optionality is
+        # expressed by the default alone (the field is then absent from the
+        # schema's "required" list). Optional[...] would emit
+        # anyOf[{type}, {null}], and several MCP clients normalize anyOf in a
+        # way that silently drops the sibling description, so optional args
+        # would reach the model with no description at all. Pydantic does not
+        # validate defaults, so a None default with a plain type is fine.
+        fields[arg_name] = (py_type, Field(default, description=desc) if desc else default)
 
     # Create the Pydantic model
     model = create_model(f"{name}_DocxArgs", **fields)  # type: ignore

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -15,7 +15,7 @@ import threading
 from email.mime.text import MIMEText
 from email import encoders
 from pathlib import Path
-from typing import Any, Dict, Optional, Literal
+from typing import Any, Dict, Literal
 from pydantic import Field, create_model
 from fastmcp import FastMCP
 from upload_tools import upload_file

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -49,11 +49,13 @@ TYPE_MAP = {
     "dict": dict, "object": dict,
 }
 
+# Optional fields use a plain type with a None default (not Optional[...]):
+# anyOf[type, null] schemas lose their description in some MCP clients.
 BASE_FIELDS: Dict[str, Any] = {
     "subject": (str, Field(..., description="Email subject line (also sets Subject header)")),
-    "to": (Optional[list[str]], Field(None, description="List of recipient email addresses")),
-    "cc": (Optional[list[str]], Field(None, description="List of CC recipient email addresses")),
-    "bcc": (Optional[list[str]], Field(None, description="List of BCC recipient email addresses")),
+    "to": (list[str], Field(None, description="List of recipient email addresses")),
+    "cc": (list[str], Field(None, description="List of CC recipient email addresses")),
+    "bcc": (list[str], Field(None, description="List of BCC recipient email addresses")),
 }
 
 
@@ -159,10 +161,12 @@ def _register_single_email_template(mcp: FastMCP, spec: Dict[str, Any]) -> bool:
 
         py_type = TYPE_MAP.get(str(arg.get("type", "string")).lower(), str)
         required = bool(arg.get("required", True))
-        field_type = py_type if required else Optional[py_type]  # type: ignore[index]
         default = arg["default"] if "default" in arg else (Ellipsis if required else None)
         desc = arg.get("description")
-        fields[arg_name] = (field_type, Field(default, description=desc) if desc is not None else default)
+        # Plain type always (no Optional/anyOf): optionality comes from the
+        # default alone, so the description stays a sibling of a flat type and
+        # survives MCP clients that drop descriptions when normalizing anyOf.
+        fields[arg_name] = (py_type, Field(default, description=desc) if desc is not None else default)
 
     model = create_model(f"{name}_Args", **fields)  # type: ignore
     # See dynamic_docx_tools: the tool annotation is resolved by name against this

--- a/tests/test_dynamic_args_schema.py
+++ b/tests/test_dynamic_args_schema.py
@@ -90,3 +90,24 @@ def test_email_optional_args_keep_flat_schema_and_description():
     required = schema.get("required", [])
     assert "req_arg" in required and "subject" in required
     assert "opt_default" not in required and "to" not in required
+
+
+def test_explicit_null_for_optional_arg_is_rejected():
+    """Documented tradeoff of the flat schema: optional args are OMITTED, not nulled.
+
+    With the plain (non-Optional) type, explicitly passing null no longer
+    validates — this test pins the behavior change down so an accidental
+    revert to Optional[...] (and thus to anyOf schemas) fails loudly.
+    """
+    import pydantic
+    import pytest
+
+    import docx_tools.dynamic_docx_tools as ddt
+
+    _model_schema(register_docx_template, DOCX_SPEC, "req_arg")
+    model = getattr(ddt, f"{DOCX_SPEC['name']}_DocxArgs")
+    # Omitting the optional arg uses its default...
+    assert model(req_arg="x").opt_default == " "
+    # ...but explicit null is rejected instead of silently accepted.
+    with pytest.raises(pydantic.ValidationError):
+        model(req_arg="x", opt_default=None)

--- a/tests/test_dynamic_args_schema.py
+++ b/tests/test_dynamic_args_schema.py
@@ -1,0 +1,92 @@
+"""Dynamic tool args must expose a FLAT JSON schema with descriptions intact.
+
+Optional args (required: false) used to be typed Optional[...], which pydantic
+renders as ``anyOf: [{type}, {"type": "null"}]`` with the description as a
+SIBLING of anyOf. Several MCP clients normalize anyOf schemas and silently drop
+that sibling description, so every optional argument reached the model with no
+description at all. Optionality must instead come from the default alone: the
+field keeps its plain type (description survives everywhere) and is simply
+absent from the schema's "required" list.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from fastmcp import FastMCP  # noqa: E402
+
+from docx_tools.dynamic_docx_tools import register_docx_template  # noqa: E402
+from email_tools.dynamic_email_tools import register_email_template  # noqa: E402
+
+DOCX_SPEC = {
+    "name": "schema_probe_docx",
+    "description": "schema probe",
+    "docx_path": "default_docx_template.docx",
+    "args": [
+        {"name": "req_arg", "type": "string", "required": True,
+         "description": "Required arg"},
+        {"name": "opt_default", "type": "string", "required": False,
+         "default": " ", "description": "Optional with default"},
+        {"name": "opt_nodefault", "type": "string", "required": False,
+         "description": "Optional without default"},
+        {"name": "opt_bool", "type": "bool", "required": False,
+         "default": True, "description": "Optional bool"},
+    ],
+}
+
+EMAIL_SPEC = {
+    "name": "schema_probe_email",
+    "description": "schema probe",
+    "html_path": "default_email_template.html",
+    "args": [
+        {"name": "req_arg", "type": "string", "required": True,
+         "description": "Required arg"},
+        {"name": "opt_default", "type": "string", "required": False,
+         "default": " ", "description": "Optional with default"},
+        {"name": "opt_nodefault", "type": "string", "required": False,
+         "description": "Optional without default"},
+    ],
+}
+
+
+def _model_schema(register, spec, probe_field):
+    mcp = FastMCP("schema-test")
+    assert register(mcp, spec), "registration failed"
+    tool = asyncio.run(mcp.get_tool(spec["name"]))
+    schema = tool.parameters
+    for definition in schema.get("$defs", {}).values():
+        if probe_field in definition.get("properties", {}):
+            return definition
+    assert probe_field in schema.get("properties", {}), "arg model not found in schema"
+    return schema
+
+
+def _assert_flat_with_description(props, names):
+    for name in names:
+        prop = props[name]
+        assert "anyOf" not in prop, f"{name}: anyOf leaks the description in some clients"
+        assert "type" in prop, f"{name}: flat type expected"
+        assert prop.get("description"), f"{name}: description missing from schema"
+
+
+def test_docx_optional_args_keep_flat_schema_and_description():
+    schema = _model_schema(register_docx_template, DOCX_SPEC, "req_arg")
+    _assert_flat_with_description(
+        schema["properties"], ["req_arg", "opt_default", "opt_nodefault", "opt_bool"])
+    # Optionality is preserved: only the truly required arg is required.
+    assert schema.get("required") == ["req_arg"]
+    assert schema["properties"]["opt_default"]["default"] == " "
+    assert schema["properties"]["opt_bool"]["type"] == "boolean"
+
+
+def test_email_optional_args_keep_flat_schema_and_description():
+    schema = _model_schema(register_email_template, EMAIL_SPEC, "req_arg")
+    _assert_flat_with_description(
+        schema["properties"], ["req_arg", "opt_default", "opt_nodefault"])
+    # Base fields stay flat too (to/cc/bcc used to be Optional[list[str]]).
+    _assert_flat_with_description(schema["properties"], ["subject", "to", "cc", "bcc"])
+    required = schema.get("required", [])
+    assert "req_arg" in required and "subject" in required
+    assert "opt_default" not in required and "to" not in required


### PR DESCRIPTION
## Problem

Optional args (`required: false`) of dynamic docx/email template tools were typed `Optional[...]`, which pydantic renders in the JSON schema as `anyOf: [{type}, {"type": "null"}]` with the description as a **sibling** of `anyOf`. Several MCP clients normalize `anyOf` schemas and silently drop that sibling description — so every optional argument reached the model **with no description at all**, while required args (flat `{type, description}` schemas) kept theirs.

Observed in production: a template with 26 args where exactly the `required: false` args arrived description-less; flipping an arg to `required: true` + default "fixed" it, which confirmed the pattern.

## Fix

Optionality is now expressed by the default alone: fields keep their **plain type** (pydantic does not validate defaults, so a `None` default with a plain type is fine) and are simply absent from the schema's `required` list. No `anyOf` is emitted anywhere.

Applies to:
- dynamic docx template args (`docx_tools/dynamic_docx_tools.py`),
- dynamic email template args and the email base fields `to`/`cc`/`bcc` (`email_tools/dynamic_email_tools.py`).

Behavioral note: explicitly passing `null` for an optional arg is now rejected instead of accepted — omit the arg instead (models do this naturally).

## Tests

New `tests/test_dynamic_args_schema.py` asserts for both docx and email registration that every arg (required, optional with default, optional without default, optional bool) has a flat `type` + `description` with no `anyOf`, and that the `required` list contains exactly the truly required args. Full suite: 649 passed (1 network-dependent pptx image test deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYQSko3quHt3XWKx77E7HS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYQSko3quHt3XWKx77E7HS)_