### PR TITLE
Fix nested-table placeholders and numbering continuation in docx renderer

### DIFF
--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -489,6 +489,11 @@ def _replace_placeholders_in_table(
                 # Note: We don't pass doc to avoid inserting lists in table cells
                 _replace_placeholders_in_paragraph(paragraph, context, doc=None,
                                                    style_map=style_map)
+            # Tables nested inside a cell (layout tables in letterheads etc.)
+            # carry placeholders too; cell.paragraphs does not descend into them.
+            for nested in cell.tables:
+                _replace_placeholders_in_table(nested, context, doc=None,
+                                               style_map=style_map)
 
 
 def _replace_placeholders_in_document(doc: DocxDocument, context: Dict[str, str],

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -138,16 +138,21 @@ def process_markdown_content(doc, content, return_elements=False,
             continue
         # --- All other block elements: delegate to block processor ---
         # Continuation survives headings, blank lines (above), block quotes and
-        # comment lines (directives attach to the block they style; both are
-        # deliberate interruptions of a numbered run — e.g. an evidence note or
-        # citation between numbered paragraphs of a legal filing). Any other
-        # block content breaks the run. A numbered line is left alone so a list
-        # that actually renders can update the count via process_list_items.
+        # complete <!-- --> comment lines. A style directive attaches to the
+        # block it styles, and that WHOLE directive-styled block (whatever its
+        # type — the dispatcher consumes directive + target together) is treated
+        # as a deliberate interruption of a numbered run, exactly like a
+        # heading: e.g. an evidence note or citation between numbered
+        # paragraphs of a legal filing. Any other block content breaks the run.
+        # A numbered line is left alone so a list that actually renders can
+        # update the count via process_list_items. An unclosed "<!--" is not a
+        # comment (it renders as literal prose), so it resets like any prose.
         stripped = line.strip()
+        is_comment_line = stripped.startswith('<!--') and stripped.endswith('-->')
         if (HEADING_PATTERN.match(stripped) is None
                 and ORDERED_LIST_PATTERN.match(stripped) is None
                 and not stripped.startswith('>')
-                and not stripped.startswith('<!--')):
+                and not is_comment_line):
             ordered_run['next'] = None
         i, block_elems = process_markdown_block(doc, lines, i,
                                                 return_element=return_elements,

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -82,11 +82,12 @@ def process_markdown_content(doc, content, return_elements=False,
     i = 0
     all_elements = []
     # Running ordered-list count: the number that would continue the most recent
-    # top-level ordered list. Preserved across headings and blank lines so a list
-    # can resume after a section heading; reset by any other block content. Lets
-    # _continues_ordered_run() accept e.g. "3." after a heading even when it is
-    # blank-separated (and so not locally genuine). A mutable cell so
-    # process_list_items can update it through process_markdown_block.
+    # top-level ordered list. Preserved across headings, blank lines, block
+    # quotes and comment-directive blocks so a list can resume after a section
+    # heading or an interposed quote/styled note; reset by any other block
+    # content. Lets _continues_ordered_run() accept e.g. "3." after a heading
+    # even when it is blank-separated (and so not locally genuine). A mutable
+    # cell so process_list_items can update it through process_markdown_block.
     ordered_run = {'next': None}
     while i < n:
         line = lines[i]
@@ -124,7 +125,8 @@ def process_markdown_content(doc, content, return_elements=False,
                 # A heading does not break ordered-list continuation.
             elif first_line.startswith('>'):
                 elem = _add_quote(doc, full_text[1:].strip(), style_map)._p
-                ordered_run['next'] = None
+                # A quote does not break ordered-list continuation (like a
+                # heading, it deliberately interrupts a numbered run).
             else:
                 para = doc.add_paragraph()
                 parse_inline_formatting(full_text, para)
@@ -135,12 +137,17 @@ def process_markdown_content(doc, content, return_elements=False,
                 doc._body._body.remove(elem)
             continue
         # --- All other block elements: delegate to block processor ---
-        # Continuation survives only headings and (above) blank lines; any other
+        # Continuation survives headings, blank lines (above), block quotes and
+        # comment lines (directives attach to the block they style; both are
+        # deliberate interruptions of a numbered run — e.g. an evidence note or
+        # citation between numbered paragraphs of a legal filing). Any other
         # block content breaks the run. A numbered line is left alone so a list
         # that actually renders can update the count via process_list_items.
         stripped = line.strip()
         if (HEADING_PATTERN.match(stripped) is None
-                and ORDERED_LIST_PATTERN.match(stripped) is None):
+                and ORDERED_LIST_PATTERN.match(stripped) is None
+                and not stripped.startswith('>')
+                and not stripped.startswith('<!--')):
             ordered_run['next'] = None
         i, block_elems = process_markdown_block(doc, lines, i,
                                                 return_element=return_elements,

--- a/tests/test_docx_list_continuation_and_br.py
+++ b/tests/test_docx_list_continuation_and_br.py
@@ -169,6 +169,33 @@ def test_prose_between_lists_breaks_continuation():
     assert any(p.text == "3. Treti" and not _is_ordered(p) for p in paras)
 
 
+def test_numbering_continues_after_blockquote():
+    # A quote deliberately interrupts a numbered run (like a heading), so the
+    # count resumes after it — e.g. a citation between numbered paragraphs of a
+    # legal filing.
+    md = "1. Prvni\n\n2. Druhy\n\n> Citace rozhodnuti.\n\n3. Treti\n"
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti"]
+    assert _start_override(doc, _num_id_of(items[2])) == "3"
+
+
+def test_numbering_continues_after_style_directive_block():
+    # A <!-- style: … --> directive and the block it styles are a deliberate
+    # interruption too (e.g. an evidence note between numbered paragraphs).
+    md = (
+        "1. Prvni\n\n2. Druhy\n\n"
+        "<!-- style: Intense Quote -->\nDukaz: smlouva ze dne 1. 1. 2026\n\n"
+        "3. Treti\n"
+    )
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti"]
+    assert _start_override(doc, _num_id_of(items[2])) == "3"
+    styled = [p for p in paras if p.text.startswith("Dukaz:")]
+    assert styled and styled[0].style.name == "Intense Quote"
+
+
 def test_standalone_non_one_pair_blank_separated_stays_prose():
     # No preceding list -> textually a date pair -> prose (date disambiguation).
     doc, paras = _render("5. Paty\n\n6. Sesty")

--- a/tests/test_docx_list_continuation_and_br.py
+++ b/tests/test_docx_list_continuation_and_br.py
@@ -196,6 +196,32 @@ def test_numbering_continues_after_style_directive_block():
     assert styled and styled[0].style.name == "Intense Quote"
 
 
+def test_directive_exemption_covers_any_styled_block():
+    # Deliberate breadth: the exemption keys off the directive, not off what
+    # kind of block it styles — ANY directive-styled block interrupts the run
+    # without resetting it, like a heading does. (The author opted in by
+    # styling the block; the residual date-misread risk is the same one the
+    # heading exemption already accepts.)
+    md = (
+        "1. Prvni\n\n2. Druhy\n\n"
+        "<!-- style: Intense Quote -->\nZaverecna poznamka bez vztahu k seznamu.\n\n"
+        "3. Treti\n"
+    )
+    doc, paras = _render(md)
+    items = [p for p in paras if _is_ordered(p)]
+    assert [p.text for p in items] == ["Prvni", "Druhy", "Treti"]
+    assert _start_override(doc, _num_id_of(items[2])) == "3"
+
+
+def test_unclosed_comment_line_is_prose_and_breaks_continuation():
+    # An unclosed "<!--" is not a comment: it renders as literal prose, so it
+    # must reset the run like any other prose paragraph (no exemption).
+    md = "1. Prvni\n\n2. Druhy\n\n<!-- style: X\n\n3. Treti\n"
+    doc, paras = _render(md)
+    assert any("<!-- style: X" in p.text for p in paras), "unclosed comment renders literally"
+    assert any(p.text == "3. Treti" and not _is_ordered(p) for p in paras)
+
+
 def test_standalone_non_one_pair_blank_separated_stays_prose():
     # No preceding list -> textually a date pair -> prose (date disambiguation).
     doc, paras = _render("5. Paty\n\n6. Sesty")

--- a/tests/test_docx_templates.py
+++ b/tests/test_docx_templates.py
@@ -428,6 +428,25 @@ class TestTablePlaceholders:
         path = save_document(doc, "table_01_simple.docx")
         assert path.exists()
 
+    def test_placeholder_in_nested_table(self):
+        """A placeholder in a table nested inside a cell is replaced too."""
+        doc = Document()
+        outer = doc.add_table(rows=1, cols=1)
+        outer.style = 'Table Grid'
+        cell = outer.cell(0, 0)
+        cell.text = "Outer {{outer_field}}"
+        inner = cell.add_table(rows=1, cols=1)
+        inner.cell(0, 0).text = "Inner {{inner_field}}"
+
+        _replace_placeholders_in_document(
+            doc, {"outer_field": "A", "inner_field": "B"})
+
+        assert "{{" not in cell.text
+        assert inner.cell(0, 0).text == "Inner B"
+
+        path = save_document(doc, "table_02_nested.docx")
+        assert path.exists()
+
     def test_markdown_in_table_cell(self):
         """Test markdown formatting in table cells."""
         doc = Document()


### PR DESCRIPTION
Two generic fixes for the dynamic DOCX template renderer.

## 1. Placeholders inside nested tables are now replaced

`_replace_placeholders_in_table` iterated `cell.paragraphs`, which does not descend into tables nested inside a cell (a common layout device in letterhead headers). Placeholders in nested tables leaked verbatim (`{{...}}`) into the generated document. The fix recurses into `cell.tables` with the same inline-only semantics as the outer table pass.

## 2. Ordered-list numbering continuation survives quotes and style-directive blocks

The running ordered-list counter (which lets numbered paragraphs resume across section headings, issue #67 follow-up) was reset by **any** non-heading block. Legal filings routinely interpose an evidence note (a `<!-- style: … -->`-styled paragraph) or a citation between numbered paragraphs — after such a block, a following `3.` failed the date-disambiguation check and rendered as plain prose instead of continuing the list.

Block quotes and comment/directive lines (plus the block a directive styles, which is consumed within the same dispatch) are deliberate interruptions of a numbered run, like headings — they no longer reset the counter. Prose paragraphs still reset it, so date disambiguation is unchanged for ordinary text.

## Tests

- `tests/test_docx_templates.py`: placeholder replacement inside a nested table.
- `tests/test_docx_list_continuation_and_br.py`: continuation across a blockquote and across a `<!-- style: … -->` styled block (asserted on numbering XML `startOverride`).

Full suite: 650 passed (1 network-dependent pptx image test deselected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYQSko3quHt3XWKx77E7HS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYQSko3quHt3XWKx77E7HS)_