### PR TITLE
Resolve list numbering and indents from the applied style

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -294,7 +294,7 @@ Nesting and combinations work, e.g. `**bold with *italic* inside**`, `**~~bold s
 This paragraph uses the "Callout" style from your template.
 ```
 
-The `<!-- style: Name -->` directive applies a style to the next block only (every item of a list, or the table). Unknown styles fall back to the default with a warning. To remap styles globally or per template, see [Custom Templates](#-custom-templates).
+The `<!-- style: Name -->` directive applies a style to the next block only — one paragraph, one heading, the whole table, or the top-level items of a list (nested items keep the `List Bullet 2/3` / `List Number 2/3` styles). On a numbered list the style's **own numbering** is used: the list restarts at `1.` with the style's numeral format and indents. The directive must be alone on its line (no trailing spaces after `-->`), and the name must match the Word style name exactly. Unknown styles fall back to the default with a warning. To remap styles globally or per template, see [Custom Templates](#-custom-templates).
 
 </details>
 

--- a/Readme.md
+++ b/Readme.md
@@ -294,7 +294,7 @@ Nesting and combinations work, e.g. `**bold with *italic* inside**`, `**~~bold s
 This paragraph uses the "Callout" style from your template.
 ```
 
-The `<!-- style: Name -->` directive applies a style to the next block only — one paragraph, one heading, the whole table, or the top-level items of a list (nested items keep the `List Bullet 2/3` / `List Number 2/3` styles). On a numbered list the style's **own numbering** is used: the list restarts at `1.` with the style's numeral format and indents. The directive must be alone on its line (no trailing spaces after `-->`), and the name must match the Word style name exactly. Unknown styles fall back to the default with a warning. To remap styles globally or per template, see [Custom Templates](#-custom-templates).
+The `<!-- style: Name -->` directive applies a style to the next block only — one paragraph, one heading, the whole table, or the top-level items of a list (nested items keep the `List Bullet 2/3` / `List Number 2/3` styles). On a numbered list the style's **own numbering** is used: the list restarts at `1.` with the style's numeral format and indents. The directive must be alone on its line, and the name must match the Word style name exactly. Unknown styles fall back to the default with a warning. To remap styles globally or per template, see [Custom Templates](#-custom-templates).
 
 </details>
 

--- a/docx_tools/block_elements.py
+++ b/docx_tools/block_elements.py
@@ -16,9 +16,11 @@ from .patterns import (
 from .inline_formatting import parse_inline_formatting
 from .patterns import _BR_RE
 from .numbering import (
-    resolve_ordered_abstract_num_id,
+    resolve_ordered_numbering,
     new_restarted_num,
     apply_numbering,
+    style_indent_attrs,
+    apply_style_indent,
 )
 from .style_map import apply_style
 
@@ -180,7 +182,11 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
     Ordered-list numbering restarts only when the explicit number ``1`` reappears
     at a level — NOT on any backward jump. ``1, 2, 1`` restarts; ``3, 4, 3`` does
     not (Word renders ``3, 4, 5``). A list starting at *N* honours that as the
-    first value via ``startOverride``.
+    first value via ``startOverride``. Restart instances are resolved from the
+    paragraph style applied at each level (so custom-mapped or directive-styled
+    lists keep their style's numeral format and indents), and any ``w:ind`` the
+    style defines is re-asserted as direct formatting so the numbering level's
+    indents don't override it (see :mod:`docx_tools.numbering`).
     Returns:
         Tuple of (next_line_index, list_of_elements | None).
     """
@@ -198,11 +204,17 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
     )
     # Ordered-list numbering restart state (see docx_tools/numbering.py). Each logical
     # list gets its own <w:num> instance so it counts independently; a new instance is
-    # started for the first item and whenever "1." reappears at this level.
+    # started for the first item and whenever "1." reappears at this level. The
+    # numbering definition (and the ilvl within it) is resolved from the paragraph
+    # style applied at this level, so custom-mapped or directive-styled lists keep
+    # their style's numeral format and indents.
     abstract_num_id = None
     numbering_root = None
+    resolved_ilvl = level
     num_resolved = False
     current_num_id = None
+    style_ind_attrs = None
+    style_ind_resolved = False
     items_emitted = 0
     last_item_number = None  # last top-level ordered number, to extend ordered_run
     while i < n:
@@ -230,14 +242,22 @@ def process_list_items(lines, start_idx, doc, is_ordered=False, level=0,
         if is_ordered:
             if current_num_id is None or (item_number == 1 and items_emitted > 0):
                 if not num_resolved:
-                    abstract_num_id, numbering_root = resolve_ordered_abstract_num_id(doc)
+                    abstract_num_id, resolved_ilvl, numbering_root = (
+                        resolve_ordered_numbering(doc, level=level, style_name=style))
                     num_resolved = True
                 if abstract_num_id is not None:
                     current_num_id = new_restarted_num(
-                        numbering_root, abstract_num_id, level, start=item_number
+                        numbering_root, abstract_num_id, resolved_ilvl, start=item_number
                     )
             if current_num_id is not None:
-                apply_numbering(paragraph, current_num_id, level)
+                apply_numbering(paragraph, current_num_id, resolved_ilvl)
+                # The direct numPr would let the numbering level's indents override
+                # the style's own; re-assert the style's indents (resolved once from
+                # the style actually applied — it may have fallen back to Normal).
+                if not style_ind_resolved:
+                    style_ind_attrs = style_indent_attrs(paragraph.style)
+                    style_ind_resolved = True
+                apply_style_indent(paragraph, style_ind_attrs)
             last_item_number = item_number
         parse_inline_formatting(item_text, paragraph)
         items_emitted += 1

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -3,6 +3,7 @@ This module contains process_markdown_content and process_markdown_block which
 orchestrate all block-level and inline parsing into a python-docx Document.
 """
 import logging
+from dataclasses import replace
 from docx.oxml.ns import qn
 from docx.text.paragraph import Paragraph
 from .patterns import (
@@ -173,6 +174,20 @@ def _add_heading(doc, level, content, style_map):
     heading = add_mapped_heading(doc, min(level, 6), style_map)
     parse_inline_formatting(content, heading)
     return heading
+
+
+def _has_explicit_style(element):
+    """True if *element* is a paragraph carrying an explicit ``w:pStyle``.
+
+    Used by the style-directive branch to spot list items that were already
+    styled through the overridden style map. Note python-docx drops ``w:pStyle``
+    when a style application falls back to the document default ("Normal"), so
+    such paragraphs are (harmlessly) re-styled by the caller.
+    """
+    if element.tag != qn('w:p'):
+        return False
+    ppr = element.find(qn('w:pPr'))
+    return ppr is not None and ppr.find(qn('w:pStyle')) is not None
 
 
 def _add_quote(doc, content, style_map):
@@ -378,16 +393,39 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
             # inserted before the trailing <w:sectPr>, so positional slicing would be
             # unreliable.
             existing = None if return_element else set(body)
+            # A style directive targeting a LIST is applied through the style map
+            # (top level only) rather than stamped onto every produced paragraph
+            # afterwards: nested items keep their own mapped level styles instead
+            # of being flattened, and ordered-list numbering resolves from the
+            # directive style itself, keeping its numeral format and indents.
+            style_name = collected.get('style')
+            target = lines[idx].strip()
+            styles_via_map = bool(style_name) and bool(
+                ORDERED_LIST_PATTERN.match(target)
+                or UNORDERED_LIST_PATTERN.match(target))
+            block_style_map = style_map
+            if styles_via_map:
+                block_style_map = replace(
+                    style_map,
+                    list_number=(style_name,) + tuple(style_map.list_number[1:]),
+                    list_bullet=(style_name,) + tuple(style_map.list_bullet[1:]),
+                )
             new_idx, block_elems = process_markdown_block(
-                doc, lines, idx, return_element=return_element, style_map=style_map,
-                directives=collected, ordered_run=ordered_run,
+                doc, lines, idx, return_element=return_element,
+                style_map=block_style_map, directives=collected,
+                ordered_run=ordered_run,
             )
             # The 'style' directive applies the named style to whatever was produced.
-            style_name = collected.get('style')
             if style_name:
                 produced = (block_elems if return_element
                             else [el for el in body if el not in existing])
                 for el in produced:
+                    # A list item already styled via the overridden style map (or a
+                    # nested level's own mapped style) carries an explicit pStyle —
+                    # leave it alone. A numbered line that rendered as plain prose
+                    # (e.g. a standalone date) has none and still gets the style.
+                    if styles_via_map and _has_explicit_style(el):
+                        continue
                     apply_style_to_block_element(doc, el, style_name)
             if return_element:
                 elements.extend(block_elems)

--- a/docx_tools/markdown_processor.py
+++ b/docx_tools/markdown_processor.py
@@ -107,7 +107,10 @@ def process_markdown_content(doc, content, return_elements=False,
                         doc._body._body.remove(p._p)
             continue
         # --- Soft line breaks (trailing two spaces) ---
-        if line.endswith('  '):
+        # A complete <!-- --> comment line is exempt: trailing spaces after the
+        # closing marker must not turn a directive (or a comment to be skipped)
+        # into soft-break prose that renders the comment text literally.
+        if line.endswith('  ') and not _is_complete_comment(line):
             paragraph_lines = []
             while i < n:
                 current_line = lines[i]
@@ -149,7 +152,7 @@ def process_markdown_content(doc, content, return_elements=False,
         # update the count via process_list_items. An unclosed "<!--" is not a
         # comment (it renders as literal prose), so it resets like any prose.
         stripped = line.strip()
-        is_comment_line = stripped.startswith('<!--') and stripped.endswith('-->')
+        is_comment_line = _is_complete_comment(line)
         if (HEADING_PATTERN.match(stripped) is None
                 and ORDERED_LIST_PATTERN.match(stripped) is None
                 and not stripped.startswith('>')
@@ -174,6 +177,12 @@ def _add_heading(doc, level, content, style_map):
     heading = add_mapped_heading(doc, min(level, 6), style_map)
     parse_inline_formatting(content, heading)
     return heading
+
+
+def _is_complete_comment(line):
+    """True if *line* (ignoring surrounding whitespace) is a whole ``<!-- -->``."""
+    stripped = line.strip()
+    return stripped.startswith('<!--') and stripped.endswith('-->')
 
 
 def _has_explicit_style(element):
@@ -400,16 +409,19 @@ def process_markdown_block(doc, lines, start_idx, return_element=True,
             # directive style itself, keeping its numeral format and indents.
             style_name = collected.get('style')
             target = lines[idx].strip()
-            styles_via_map = bool(style_name) and bool(
-                ORDERED_LIST_PATTERN.match(target)
-                or UNORDERED_LIST_PATTERN.match(target))
+            target_is_ordered = bool(ORDERED_LIST_PATTERN.match(target))
+            styles_via_map = bool(style_name) and (
+                target_is_ordered or bool(UNORDERED_LIST_PATTERN.match(target)))
             block_style_map = style_map
             if styles_via_map:
-                block_style_map = replace(
-                    style_map,
-                    list_number=(style_name,) + tuple(style_map.list_number[1:]),
-                    list_bullet=(style_name,) + tuple(style_map.list_bullet[1:]),
-                )
+                if target_is_ordered:
+                    block_style_map = replace(
+                        style_map,
+                        list_number=(style_name,) + tuple(style_map.list_number[1:]))
+                else:
+                    block_style_map = replace(
+                        style_map,
+                        list_bullet=(style_name,) + tuple(style_map.list_bullet[1:]))
             new_idx, block_elems = process_markdown_block(
                 doc, lines, idx, return_element=return_element,
                 style_map=block_style_map, directives=collected,

--- a/docx_tools/numbering.py
+++ b/docx_tools/numbering.py
@@ -111,11 +111,19 @@ def _clamp_ilvl(numbering_root, abstract_num_id, ilvl):
 
 
 def _find_decimal_abstract(numbering_root):
-    """Return the id of any existing decimal abstractNum, or ``None``."""
-    for abstract in numbering_root.xpath('./w:abstractNum'):
-        fmt = abstract.xpath('./w:lvl[@w:ilvl="0"]/w:numFmt/@w:val')
-        if fmt and fmt[0] == 'decimal':
-            return abstract.get(qn('w:abstractNumId'))
+    """Return the id of any existing decimal abstractNum, or ``None``.
+
+    Uses qualified-name ``findall`` rather than ``.xpath('./w:…')`` because
+    ``<w:abstractNum>`` has no registered oxml class — on plain lxml elements
+    the ``w:`` prefix is undefined and such an xpath raises.
+    """
+    for abstract in numbering_root.findall(qn('w:abstractNum')):
+        for lvl in abstract.findall(qn('w:lvl')):
+            if lvl.get(qn('w:ilvl')) != '0':
+                continue
+            fmt = lvl.find(qn('w:numFmt'))
+            if fmt is not None and fmt.get(qn('w:val')) == 'decimal':
+                return abstract.get(qn('w:abstractNumId'))
     return None
 
 

--- a/docx_tools/numbering.py
+++ b/docx_tools/numbering.py
@@ -42,21 +42,72 @@ def _numbering_root(doc):
     return numbering_part.element
 
 
-def _abstract_id_from_style(doc, numbering_root, style_name):
-    """Resolve the abstractNumId backing *style_name*, or ``None`` if it has none."""
+def _style_numbering(doc, numbering_root, style_name):
+    """Return ``(abstract_num_id, ilvl)`` declared by *style_name*'s numbering.
+
+    Follows the style's ``basedOn`` chain so a style that inherits its list
+    definition still resolves. The declared ``w:ilvl`` (default 0) identifies
+    which level of the abstract definition the style renders — e.g. Word's
+    built-in ``List Number 2`` points at ``ilvl 1`` of a shared multi-level
+    definition, while a template with three single-level definitions declares
+    no ``ilvl`` at all. Returns ``(None, None)`` when the style is missing or
+    carries no usable numbering reference.
+    """
     try:
-        style_el = doc.styles[style_name]._element
+        style = doc.styles[style_name]
     except KeyError:
-        return None
-    num_ids = style_el.xpath('.//w:numPr/w:numId/@w:val')
-    if not num_ids:
-        return None
-    try:
-        num = numbering_root.num_having_numId(int(num_ids[0]))
-    except (KeyError, ValueError):
-        return None
-    # Normalise to str so all three resolver paths return the same type.
-    return str(num.abstractNumId.val)
+        return None, None
+    seen = set()
+    while style is not None and style.style_id not in seen:
+        seen.add(style.style_id)
+        style_el = style._element
+        num_ids = style_el.xpath('./w:pPr/w:numPr/w:numId/@w:val')
+        if num_ids:
+            try:
+                num = numbering_root.num_having_numId(int(num_ids[0]))
+            except (KeyError, ValueError):
+                return None, None
+            ilvls = style_el.xpath('./w:pPr/w:numPr/w:ilvl/@w:val')
+            try:
+                ilvl = int(ilvls[0]) if ilvls else 0
+            except ValueError:
+                ilvl = 0
+            # Normalise to str so all resolver paths return the same type.
+            return str(num.abstractNumId.val), ilvl
+        style = style.base_style
+    return None, None
+
+
+def _abstract_defined_ilvls(numbering_root, abstract_num_id):
+    """Return the sorted ``ilvl`` values the abstract definition declares.
+
+    Uses qualified-name ``findall`` rather than ``.xpath('./w:…')`` because
+    ``<w:abstractNum>`` has no registered oxml class — on plain lxml elements
+    the ``w:`` prefix is undefined and such an xpath raises.
+    """
+    for abstract in numbering_root.findall(qn('w:abstractNum')):
+        if abstract.get(qn('w:abstractNumId')) == str(abstract_num_id):
+            ilvls = []
+            for lvl in abstract.findall(qn('w:lvl')):
+                try:
+                    ilvls.append(int(lvl.get(qn('w:ilvl'))))
+                except (TypeError, ValueError):
+                    pass
+            return sorted(ilvls)
+    return []
+
+
+def _clamp_ilvl(numbering_root, abstract_num_id, ilvl):
+    """Clamp *ilvl* to a level the abstract actually defines.
+
+    Referencing an undefined level renders without number or indent in Word,
+    so fall back to the nearest defined level below (or the lowest defined).
+    """
+    defined = _abstract_defined_ilvls(numbering_root, abstract_num_id)
+    if not defined or ilvl in defined:
+        return ilvl
+    lower = [v for v in defined if v <= ilvl]
+    return max(lower) if lower else defined[0]
 
 
 def _find_decimal_abstract(numbering_root):
@@ -111,53 +162,101 @@ def _create_decimal_abstract(numbering_root):
     return str(abstract_id)
 
 
-def resolve_ordered_abstract_num_id(doc):
-    """Return ``(abstract_num_id, numbering_root)`` for ordered-list restart instances.
+def resolve_ordered_numbering(doc, level=0, style_name=None):
+    """Return ``(abstract_num_id, ilvl, numbering_root)`` for restart instances.
 
-    Prefers the abstract definition backing the ``List Number`` style so restarted lists
-    keep the template's numbering format; falls back to any decimal definition, and finally
-    synthesizes one (degraded mode). Returns ``(None, None)`` if no numbering part is
-    available or synthesis fails, so the caller renders lists without restart rather than
-    raising.
+    *level* is the 0-based markdown nesting level; *style_name* is the ordered-list
+    paragraph style actually applied at that level (a ``style_mapping`` override or a
+    ``<!-- style: … -->`` directive style). Resolution order:
 
-    Limitation: this searches only the hardcoded ``_ORDERED_LIST_STYLES`` names and is
-    unaware of a custom ``StyleMap.list_number`` mapping. If a template maps
-    ``list_number`` to a name not in ``_ORDERED_LIST_STYLES`` and carries no built-in
-    ``List Number`` style, restart numbering falls back to the synthesized *decimal*
-    format rather than the custom style's format (e.g. Roman numerals or letters). The
-    paragraph style — and thus its appearance — is still applied; only the numeral format
-    of the restarted instance degrades.
+    1. *style_name*'s own numbering (declared ``numId`` + ``ilvl``, following
+       ``basedOn``) — restarted lists keep that style's numeral format and level
+       indents instead of degrading to the built-in ``List Number`` definition.
+    2. The built-in style for this level (``List Number`` / ``… 2`` / ``… 3``),
+       then the other built-ins — each with its *own* declared ``ilvl``, so a
+       template whose level-2 style carries a separate single-level definition
+       restarts that definition's level 0 rather than pointing at an ``ilvl``
+       the abstract does not define (which Word renders unnumbered).
+    3. Any existing decimal ``abstractNum`` (``ilvl`` clamped to its levels).
+    4. A synthesized minimal decimal definition (degraded mode).
+
+    Returns ``(None, None, None)`` if no numbering part is available or synthesis
+    fails, so the caller renders lists without restart rather than raising.
     """
     try:
         numbering_root = _numbering_root(doc)
     except RuntimeError:
         logger.warning("No numbering part available; ordered lists will not restart.",
                        exc_info=True)
-        return None, None
-    for style_name in _ORDERED_LIST_STYLES:
-        abstract_id = _abstract_id_from_style(doc, numbering_root, style_name)
+        return None, None, None
+    builtin = _ORDERED_LIST_STYLES[min(level, len(_ORDERED_LIST_STYLES) - 1)]
+    candidates = [style_name] if style_name else []
+    candidates.append(builtin)
+    candidates.extend(name for name in _ORDERED_LIST_STYLES if name != builtin)
+    seen = set()
+    for name in candidates:
+        if name in seen:
+            continue
+        seen.add(name)
+        abstract_id, ilvl = _style_numbering(doc, numbering_root, name)
         if abstract_id is not None:
-            return abstract_id, numbering_root
+            return abstract_id, _clamp_ilvl(numbering_root, abstract_id, ilvl), numbering_root
     abstract_id = _find_decimal_abstract(numbering_root)
     if abstract_id is not None:
-        return abstract_id, numbering_root
+        return abstract_id, _clamp_ilvl(numbering_root, abstract_id, level), numbering_root
     try:
-        return _create_decimal_abstract(numbering_root), numbering_root
+        abstract_id = _create_decimal_abstract(numbering_root)
+        return abstract_id, min(level, 2), numbering_root
     except Exception:
         logger.warning("Could not synthesize a numbering definition; "
                        "ordered lists will not restart.", exc_info=True)
-        return None, None
+        return None, None, None
 
 
-def new_restarted_num(numbering_root, abstract_num_id, level, start=1):
-    """Create a fresh ``<w:num>`` restarting *level* at *start*; return its numId."""
+def new_restarted_num(numbering_root, abstract_num_id, ilvl, start=1):
+    """Create a fresh ``<w:num>`` restarting *ilvl* at *start*; return its numId."""
     num = numbering_root.add_num(abstract_num_id)
-    num.add_lvlOverride(level).add_startOverride(start)
+    num.add_lvlOverride(ilvl).add_startOverride(start)
     return num.numId
 
 
-def apply_numbering(paragraph, num_id, level):
+def apply_numbering(paragraph, num_id, ilvl):
     """Attach an explicit ``<w:numPr>`` (numId + ilvl) to *paragraph*."""
     numPr = paragraph._p.get_or_add_pPr().get_or_add_numPr()
     numPr.get_or_add_numId().val = num_id
-    numPr.get_or_add_ilvl().val = level
+    numPr.get_or_add_ilvl().val = ilvl
+
+
+def style_indent_attrs(style):
+    """Return the ``w:ind`` attributes *style* defines (following ``basedOn``), or None.
+
+    *style* is a python-docx paragraph style object (e.g. ``paragraph.style``).
+    """
+    seen = set()
+    while style is not None and style.style_id not in seen:
+        seen.add(style.style_id)
+        ppr = style._element.find(qn('w:pPr'))
+        if ppr is not None:
+            ind = ppr.find(qn('w:ind'))
+            if ind is not None:
+                return dict(ind.attrib)
+        style = style.base_style
+    return None
+
+
+def apply_style_indent(paragraph, ind_attrs):
+    """Re-assert a style's indents as direct formatting on *paragraph*.
+
+    Word treats the ``w:ind`` inside a numbering level referenced by a *direct*
+    ``w:numPr`` as direct formatting, silently overriding the paragraph style's
+    own indents — so a template's styled left indent would be lost on every
+    ordered-list item. Re-stating the style's ``w:ind`` directly on the
+    paragraph restores the intended precedence; attributes the style does not
+    define (typically the number's ``hanging``) still come from the numbering
+    level, because ``w:ind`` attributes merge individually across the cascade.
+    """
+    if not ind_attrs:
+        return
+    ind = paragraph._p.get_or_add_pPr().get_or_add_ind()
+    for key, value in ind_attrs.items():
+        ind.set(key, value)

--- a/tests/test_docx_list_restart.py
+++ b/tests/test_docx_list_restart.py
@@ -18,7 +18,7 @@ project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
 from docx_tools.block_elements import process_list_items  # noqa: E402
-from docx_tools.numbering import resolve_ordered_abstract_num_id  # noqa: E402
+from docx_tools.numbering import resolve_ordered_numbering  # noqa: E402
 
 
 def _new_doc_with_default_styles():
@@ -139,8 +139,9 @@ def test_restart_survives_return_elements_roundtrip():
 def test_resolve_uses_list_number_style_abstract():
     """Restart instances reuse the template's ``List Number`` numbering format."""
     doc = _new_doc_with_default_styles()
-    abstract_id, numbering = resolve_ordered_abstract_num_id(doc)
+    abstract_id, ilvl, numbering = resolve_ordered_numbering(doc)
     assert abstract_id is not None
+    assert ilvl == 0
     # It should match what the List Number style points at.
     style_el = doc.styles["List Number"]._element
     style_num = style_el.xpath('.//w:numPr/w:numId/@w:val')[0]
@@ -151,7 +152,7 @@ def test_resolve_uses_list_number_style_abstract():
 def test_resolve_returns_str_abstract_id():
     """All resolver paths return a str abstract id (consistent type)."""
     doc = _new_doc_with_default_styles()
-    abstract_id, _ = resolve_ordered_abstract_num_id(doc)
+    abstract_id, _ilvl, _ = resolve_ordered_numbering(doc)
     assert isinstance(abstract_id, str)
 
 

--- a/tests/test_docx_style_numbering.py
+++ b/tests/test_docx_style_numbering.py
@@ -192,6 +192,32 @@ def test_resolver_prefers_style_name_over_builtins():
     assert ilvl == 0
 
 
+def test_decimal_fallback_scan_survives_unregistered_abstract_elements():
+    """Priority-3 fallback: no usable list styles, but a decimal abstractNum exists.
+
+    ``w:abstractNum`` has no registered oxml class, so ``w:``-prefixed xpath on
+    it raises XPathEvalError — the scan must use qualified-name lookups. Deleting
+    the built-in numbered styles forces resolution onto this path.
+    """
+    doc = Document()
+    doc.part.numbering_part  # materialise the numbering part (holds decimal abstracts)
+    for name in ("List Number", "List Number 2", "List Number 3"):
+        doc.styles[name].delete()
+
+    abstract_id, ilvl, root = resolve_ordered_numbering(doc, level=0)
+
+    assert abstract_id is not None and root is not None
+    assert ilvl == 0
+    # The returned abstract really is decimal at ilvl 0.
+    fmts = root.xpath(
+        f'./w:abstractNum[@w:abstractNumId="{abstract_id}"]'
+        f'/w:lvl[@w:ilvl="0"]/w:numFmt/@w:val')
+    assert fmts == ["decimal"]
+    # And rendering still attaches restart numbering end-to-end.
+    process_markdown_content(doc, "1. one\n2. two\n")
+    assert _abstract_of_para(doc, _para(doc, "one")) == str(abstract_id)
+
+
 def test_resolver_follows_based_on_chain():
     """A style without its own numPr inherits the numbering of its base style."""
     doc = Document()

--- a/tests/test_docx_style_numbering.py
+++ b/tests/test_docx_style_numbering.py
@@ -1,0 +1,301 @@
+"""Tests for style-aware ordered-list numbering and indents.
+
+Three behaviours introduced together (follow-up to issues #66/#67):
+
+1. Restart numbering instances are resolved from the ordered-list *style
+   actually applied* at each level — a ``style_mapping`` override or a
+   ``<!-- style: … -->`` directive — so restarted lists keep that style's own
+   numeral format; nested levels use the level style's own declared
+   ``numId``/``ilvl`` instead of assuming a multi-level ``List Number`` abstract.
+2. Any ``w:ind`` the applied style defines is re-asserted as direct paragraph
+   formatting, because a direct ``w:numPr`` otherwise lets the numbering level's
+   indents silently override the style's.
+3. A ``<!-- style: … -->`` directive on a list styles the *top level* through
+   the style map (nested items keep ``List Number 2/3`` / ``List Bullet 2/3``)
+   instead of flattening every produced paragraph to the directive style.
+
+Assertions are made on the numbering/paragraph XML because Word computes the
+visible numbers and indents at display time.
+"""
+import sys
+from pathlib import Path
+
+from docx import Document
+from docx.enum.style import WD_STYLE_TYPE
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+from docx.shared import Inches
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from docx_tools.markdown_processor import process_markdown_content  # noqa: E402
+from docx_tools.numbering import resolve_ordered_numbering  # noqa: E402
+from docx_tools.style_map import build_style_map  # noqa: E402
+
+
+def _add_numbered_style(doc, name, num_fmt="upperRoman", lvl_left=2880,
+                        lvl_hanging=720, style_left_inches=None):
+    """Register paragraph style *name* backed by its own single-level numbering.
+
+    Mimics a custom template's numbered style: a dedicated ``abstractNum`` (with
+    its own numeral format and level indents), a ``num`` instance, and a style
+    whose ``pPr`` references that instance. Returns the abstractNumId (str).
+    """
+    numbering = doc.part.numbering_part.element
+
+    def _el(tag, **attrs):
+        el = OxmlElement(tag)
+        for key, value in attrs.items():
+            el.set(qn('w:' + key), value)
+        return el
+
+    existing = [int(v) for v in numbering.xpath('./w:abstractNum/@w:abstractNumId')]
+    abstract_id = max(existing) + 1 if existing else 0
+    abstract = _el('w:abstractNum', abstractNumId=str(abstract_id))
+    abstract.append(_el('w:multiLevelType', val='singleLevel'))
+    lvl = _el('w:lvl', ilvl='0')
+    lvl.append(_el('w:start', val='1'))
+    lvl.append(_el('w:numFmt', val=num_fmt))
+    lvl.append(_el('w:lvlText', val='%1.'))
+    lvl.append(_el('w:lvlJc', val='left'))
+    lvl_ppr = OxmlElement('w:pPr')
+    lvl_ppr.append(_el('w:ind', left=str(lvl_left), hanging=str(lvl_hanging)))
+    lvl.append(lvl_ppr)
+    abstract.append(lvl)
+    first_num = numbering.find(qn('w:num'))
+    if first_num is not None:
+        first_num.addprevious(abstract)
+    else:
+        numbering.append(abstract)
+    num = numbering.add_num(abstract_id)
+
+    style = doc.styles.add_style(name, WD_STYLE_TYPE.PARAGRAPH)
+    style_ppr = style._element.get_or_add_pPr()
+    num_pr = style_ppr.get_or_add_numPr()
+    num_pr.get_or_add_numId().val = num.numId
+    if style_left_inches is not None:
+        style.paragraph_format.left_indent = Inches(style_left_inches)
+    return str(abstract_id)
+
+
+def _para(doc, text):
+    for p in doc.paragraphs:
+        if p.text == text:
+            return p
+    raise AssertionError(f"no paragraph with text {text!r}")
+
+
+def _abstract_of_para(doc, paragraph):
+    """Abstract numbering id behind the paragraph's direct ``numPr``, or None."""
+    vals = paragraph._p.xpath('./w:pPr/w:numPr/w:numId/@w:val')
+    if not vals:
+        return None
+    numbering = doc.part.numbering_part.element
+    return str(numbering.num_having_numId(int(vals[0])).abstractNumId.val)
+
+
+def _ilvl_of_para(paragraph):
+    vals = paragraph._p.xpath('./w:pPr/w:numPr/w:ilvl/@w:val')
+    return int(vals[0]) if vals else None
+
+
+def _direct_ind(paragraph):
+    """The paragraph's direct ``w:ind`` attributes (local names), or None."""
+    inds = paragraph._p.xpath('./w:pPr/w:ind')
+    if not inds:
+        return None
+    return {key.rsplit('}', 1)[-1]: value for key, value in inds[0].attrib.items()}
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — numbering resolves from the style actually applied
+# ---------------------------------------------------------------------------
+
+def test_mapped_list_number_style_uses_its_own_numbering():
+    """A style_mapping'd ordered style restarts with ITS abstract, not List Number's."""
+    doc = Document()
+    abstract_id = _add_numbered_style(doc, "Legal Number")
+    style_map = build_style_map({"list_number": "Legal Number"})
+
+    process_markdown_content(doc, "1. one\n2. two\n", style_map=style_map)
+
+    one, two = _para(doc, "one"), _para(doc, "two")
+    assert one.style.name == "Legal Number"
+    assert _abstract_of_para(doc, one) == abstract_id
+    assert _abstract_of_para(doc, two) == abstract_id
+    assert _ilvl_of_para(one) == 0
+
+
+def test_directive_list_uses_styles_own_numbering():
+    """A directive-styled numbered list restarts with the directive style's abstract."""
+    doc = Document()
+    abstract_id = _add_numbered_style(doc, "Legal Number")
+
+    process_markdown_content(doc, "<!-- style: Legal Number -->\n1. one\n2. two\n")
+
+    one = _para(doc, "one")
+    assert one.style.name == "Legal Number"
+    assert _abstract_of_para(doc, one) == abstract_id
+    # The restart instance carries a startOverride at the style's declared level.
+    num_id = one._p.xpath('./w:pPr/w:numPr/w:numId/@w:val')[0]
+    numbering = doc.part.numbering_part.element
+    num = numbering.num_having_numId(int(num_id))
+    assert num.xpath('./w:lvlOverride[@w:ilvl="0"]/w:startOverride/@w:val') == ["1"]
+
+
+def test_nested_level_uses_level_styles_own_numbering():
+    """In a template with single-level abstracts, nested items must not point at
+    an undefined ilvl of the parent's abstract (Word would render no number)."""
+    doc = Document()  # blank python-docx template: every abstract is single-level
+
+    process_markdown_content(doc, "1. parent\n   1. child\n")
+
+    parent, child = _para(doc, "parent"), _para(doc, "child")
+    assert child.style.name == "List Number 2"
+    # The child resolves List Number 2's own numbering (declared ilvl 0 here),
+    # on a different abstract than the parent's.
+    numbering = doc.part.numbering_part.element
+    style_el = doc.styles["List Number 2"]._element
+    style_num = int(style_el.xpath('./w:pPr/w:numPr/w:numId/@w:val')[0])
+    expected_abstract = str(numbering.num_having_numId(style_num).abstractNumId.val)
+    assert _abstract_of_para(doc, child) == expected_abstract
+    assert _abstract_of_para(doc, child) != _abstract_of_para(doc, parent)
+    # The referenced ilvl must exist in the abstract definition.
+    child_ilvl = _ilvl_of_para(child)
+    defined = numbering.xpath(
+        f'./w:abstractNum[@w:abstractNumId="{expected_abstract}"]/w:lvl/@w:ilvl')
+    assert str(child_ilvl) in defined
+
+
+def test_missing_custom_style_falls_back_to_builtin_numbering():
+    """An unknown mapped style degrades to the List Number chain, not to nothing."""
+    doc = Document()
+    style_map = build_style_map({"list_number": "Nonexistent"})
+
+    process_markdown_content(doc, "1. one\n2. two\n", style_map=style_map)
+
+    one = _para(doc, "one")
+    numbering = doc.part.numbering_part.element
+    style_el = doc.styles["List Number"]._element
+    style_num = int(style_el.xpath('./w:pPr/w:numPr/w:numId/@w:val')[0])
+    expected_abstract = str(numbering.num_having_numId(style_num).abstractNumId.val)
+    assert _abstract_of_para(doc, one) == expected_abstract
+
+
+def test_resolver_prefers_style_name_over_builtins():
+    doc = Document()
+    abstract_id = _add_numbered_style(doc, "Legal Number")
+    resolved, ilvl, _root = resolve_ordered_numbering(doc, level=0,
+                                                      style_name="Legal Number")
+    assert resolved == abstract_id
+    assert ilvl == 0
+
+
+def test_resolver_follows_based_on_chain():
+    """A style without its own numPr inherits the numbering of its base style."""
+    doc = Document()
+    abstract_id = _add_numbered_style(doc, "Legal Number")
+    derived = doc.styles.add_style("Legal Number Tight", WD_STYLE_TYPE.PARAGRAPH)
+    derived.base_style = doc.styles["Legal Number"]
+    resolved, ilvl, _root = resolve_ordered_numbering(doc, level=0,
+                                                      style_name="Legal Number Tight")
+    assert resolved == abstract_id
+    assert ilvl == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — the style's indents survive the direct numPr
+# ---------------------------------------------------------------------------
+
+def test_style_indent_reasserted_on_ordered_items():
+    """The style's w:ind is restated as direct formatting on every ordered item."""
+    doc = Document()
+    _add_numbered_style(doc, "Legal Number", style_left_inches=1.0)
+
+    process_markdown_content(doc, "<!-- style: Legal Number -->\n1. one\n2. two\n")
+
+    for text in ("one", "two"):
+        ind = _direct_ind(_para(doc, text))
+        assert ind is not None, f"item {text!r} lost the style's indent"
+        assert ind.get("left") == str(int(Inches(1.0).twips))
+        # The style defines no hanging — the numbering level's hanging still
+        # applies (w:ind attributes merge individually), so none is stamped.
+        assert "hanging" not in ind
+
+
+def test_no_direct_indent_when_style_defines_none():
+    """Without a styled indent, no direct w:ind is invented (template's numbering
+    level keeps full control, as before)."""
+    doc = Document()  # blank template: List Number style has no w:ind
+
+    process_markdown_content(doc, "1. one\n2. two\n")
+
+    assert _direct_ind(_para(doc, "one")) is None
+
+
+def test_default_template_ordered_items_get_style_indent():
+    """The shipped default template styles List Number at 576 twips; items must
+    carry it directly so it beats the abstract's 432-twip level indent."""
+    default = project_root / "default_templates" / "default_docx_template.docx"
+    doc = Document(str(default))
+    style_ind = doc.styles["List Number"]._element.xpath('./w:pPr/w:ind/@w:left')
+    assert style_ind, "fixture expectation: default template styles List Number's indent"
+
+    process_markdown_content(doc, "1. one\n")
+
+    ind = _direct_ind(_para(doc, "one"))
+    assert ind is not None and ind.get("left") == style_ind[0]
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — directive styles lists via the style map, keeping nested levels
+# ---------------------------------------------------------------------------
+
+def test_directive_list_keeps_nested_number_styles():
+    doc = Document()
+    _add_numbered_style(doc, "Legal Number")
+
+    process_markdown_content(
+        doc, "<!-- style: Legal Number -->\n1. parent\n   1. child\n")
+
+    assert _para(doc, "parent").style.name == "Legal Number"
+    assert _para(doc, "child").style.name == "List Number 2"
+
+
+def test_directive_bullet_list_keeps_nested_bullet_styles():
+    doc = Document()
+    doc.styles.add_style("Fancy Bullet", WD_STYLE_TYPE.PARAGRAPH)
+
+    process_markdown_content(
+        doc, "<!-- style: Fancy Bullet -->\n- parent\n  - child\n")
+
+    assert _para(doc, "parent").style.name == "Fancy Bullet"
+    assert _para(doc, "child").style.name == "List Bullet 2"
+
+
+def test_directive_on_nongenuine_numbered_line_still_styles_paragraph():
+    """A numbered line that renders as prose (a standalone date) is still styled."""
+    doc = Document()
+    doc.styles.add_style("Callout", WD_STYLE_TYPE.PARAGRAPH)
+
+    process_markdown_content(doc, "<!-- style: Callout -->\n23. brezna 2026\n")
+
+    para = _para(doc, "23. brezna 2026")
+    assert para.style.name == "Callout"
+    assert _ilvl_of_para(para) is None, "must not have been rendered as a list"
+
+
+def test_directive_list_in_detached_mode_keeps_nested_styles():
+    """The placeholder path (return_elements=True) gets the same level styling."""
+    from docx.text.paragraph import Paragraph
+    doc = Document()
+    _add_numbered_style(doc, "Legal Number")
+
+    elements = process_markdown_content(
+        doc, "<!-- style: Legal Number -->\n1. parent\n   1. child\n",
+        return_elements=True)
+
+    styles = [Paragraph(e, doc._body).style.name for e in elements
+              if e.tag == qn('w:p')]
+    assert styles == ["Legal Number", "List Number 2"]

--- a/tests/test_docx_style_tag.py
+++ b/tests/test_docx_style_tag.py
@@ -116,6 +116,24 @@ def test_stacked_directives_compose_on_a_table():
     assert table.rows[0].cells[1].width > table.rows[0].cells[0].width
 
 
+def test_directive_with_trailing_spaces_still_applies():
+    """Trailing spaces after ``-->`` must not demote the directive to soft-break
+    prose (which would render the comment text literally)."""
+    doc = _doc("Callout")
+    start = len(doc.paragraphs)
+    process_markdown_content(doc, "<!-- style: Callout -->  \nhello\n")
+    assert _style_of(doc, start, "hello") == "Callout"
+    assert not any("<!--" in p.text for p in doc.paragraphs[start:])
+
+
+def test_nondirective_comment_with_trailing_spaces_is_skipped():
+    doc = Document()
+    start = len(doc.paragraphs)
+    process_markdown_content(doc, "before\n\n<!-- a note -->  \nafter\n")
+    texts = [p.text for p in doc.paragraphs[start:] if p.text]
+    assert texts == ["before", "after"]
+
+
 def test_nondirective_comment_is_skipped_not_rendered():
     doc = Document()
     start = len(doc.paragraphs)


### PR DESCRIPTION
## Summary

Three related fixes for ordered-list rendering with custom styles (follow-up to #66/#67), addressing reports that the `<!-- style: ... -->` directive and `style_mapping` overrides lose the style's numbering format and left/hanging indents.

1. **Numbering resolves from the style actually applied.** `resolve_ordered_abstract_num_id` is replaced by `resolve_ordered_numbering(doc, level, style_name)`, which tries the effective style first (directive or `style_mapping` override, following the `basedOn` chain and honoring the style's declared `numId`/`ilvl`), then the built-in `List Number/2/3` for that level, then the existing decimal-scan and synthesized fallbacks. The resolved `ilvl` is clamped to levels the abstract actually defines — previously nested items pointed at `ilvl 1/2` of single-level abstracts, which Word renders unnumbered.

2. **Style indents survive the direct `numPr`.** A direct `w:numPr` makes Word treat the numbering level's `w:ind` as direct formatting, silently overriding the paragraph style's own indents — including in the shipped default template (styled 576 twips, rendered 432). The renderer now re-asserts the applied style's `w:ind` as direct formatting on ordered items; attributes the style doesn't define (typically the number's `hanging`) still come from the numbering level, since `w:ind` attributes merge individually.

3. **The style directive styles lists through the style map.** When `<!-- style: X -->` targets a list, X is injected as the level-0 style in a per-block `StyleMap` instead of being stamped on every produced paragraph. Nested items keep `List Number 2/3` / `List Bullet 2/3` instead of being flattened, and a directive-styled numbered list restarts at 1 using the directive style's own numeral format and indents. A numbered line that renders as prose (e.g. a standalone date) still gets the style.

Also fixes a latent crash in the decimal-abstract fallback scan (`w:abstractNum` has no registered oxml class, so `w:`-prefixed xpath on it raises `XPathEvalError`), and documents the directive's exact scope and syntax rules in the Readme.

## Testing

- 13 new tests in `tests/test_docx_style_numbering.py`: custom-style abstract resolution (mapped and directive), `basedOn` inheritance, nested lists in single-level-abstract templates, missing-style fallback, indent re-assertion (and its absence when the style defines none), default-template indent regression, nested style preservation for numbered and bullet lists, non-genuine numbered lines, and the detached/placeholder path.
- Two existing resolver tests updated to the new API.
- Full suite: 668 passed; the only failure is a pre-existing PPTX test that downloads an image from the internet (unavailable in the sandbox, unrelated).
- Verified end-to-end on a simulated legal template: level-0 items carry the custom style, a restart instance of its upperRoman abstract, and the style's own indent restated directly; nested items keep `List Number 2` with a defined numbering level; a second directive block restarts at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8KnbPTAZ5m6aSq2uZKkaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8KnbPTAZ5m6aSq2uZKkaP)_