### PR TITLE
Librechat integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ RUN_BLOCKING_MAX_WORKERS=
 STATELESS_HTTP=
 
 # --- Storage / Upload strategy ---
-# One of: LOCAL, S3, GCS, AZURE
+# One of: LOCAL, S3, GCS, AZURE, MINIO, LIBRECHAT
 UPLOAD_STRATEGY=LOCAL
 # How long generated download links remain valid (in seconds) for S3/GCS/AZURE
 SIGNED_URL_EXPIRES_IN=3600
@@ -101,3 +101,28 @@ AZURE_STORAGE_ACCOUNT_KEY=
 AZURE_CONTAINER=
 # Optional custom endpoint (sovereign clouds); defaults to https://<account>.blob.core.windows.net
 AZURE_BLOB_ENDPOINT=
+
+# --- LibreChat Integration (required when UPLOAD_STRATEGY=LIBRECHAT) ---
+# When UPLOAD_STRATEGY=LIBRECHAT, documents are uploaded to LibreChat's service
+# endpoint and returned as MCP file artifacts that appear as attachments in the
+# chat UI. This enables seamless document generation within LibreChat conversations.
+#
+# LIBRECHAT_SERVICE_URL: Full URL to LibreChat's service files endpoint.
+#   Typically: http://api:3080/api/service/files (inside Docker network)
+#   Or: http://localhost:3080/api/service/files (local development)
+#
+# LIBRECHAT_SERVICE_TOKEN: Service token for authentication.
+#   Must match MCP_SERVICE_TOKEN configured in LibreChat's .env file.
+#   Generate with: openssl rand -hex 32
+#
+# LibreChat librechat.yaml MCP configuration example:
+#   mcpServers:
+#     Office-documents:
+#       type: streamable-http
+#       url: http://mcp-office-docs:8958/mcp
+#       headers:
+#         X-User-Id: "{{LIBRECHAT_USER_ID}}"
+#         X-User-Email: "{{LIBRECHAT_USER_EMAIL}}"
+#
+LIBRECHAT_SERVICE_URL=
+LIBRECHAT_SERVICE_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ config/
 *.tmp
 # FastHTML session key (admin UI)
 .sesskey
+
+# Agent Zero project files (local only)
+.a0proj/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,16 @@ main.py                  ← Registers all MCP tools on a single FastMCP instanc
 - **Error handling in tools**: raise `fastmcp.exceptions.ToolError` for user-facing errors; use `RuntimeError` in upload/backend layers.
 - **Logging**: use `logging.getLogger(__name__)` everywhere. Level controlled by `DEBUG` env var only.
 
+## Filename Generation
+
+**UUID prefix control** (`add_unique_prefix` parameter):
+- All MCP tools accept an optional `add_unique_prefix: bool` parameter (default `False`).
+- When `False` (default): filenames are clean without UUID prefix (e.g., `My_Report.docx`).
+- When `True`: adds an 8-character UUID prefix for server-side uniqueness (e.g., `ff8ae81d_My_Report.docx`).
+- **Rationale**: LibreChat adds its own UUID prefix during file storage (`3deca384-6c9a-492a-ae2b-08ce22122cba__My_Report.docx`), making the MCP server prefix redundant in most cases.
+- **Implementation**: The parameter flows through `upload_file_async()` → `upload_file()` → `generate_named_object_name()` in `upload_tools/`.
+- **Dynamic tools**: YAML-defined tools can include `add_unique_prefix` in their payload; the parameter is extracted with `.get("add_unique_prefix", False)` in `dynamic_docx_tools.py` and `dynamic_email_tools.py`.
+
 ## Adding a New Document Tool
 
 1. Create `<type>_tools/` package with `__init__.py`, `base_<type>_tool.py`, and optional `helpers.py`.

--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,8 @@ Just ask your AI to _"create a sales presentation"_ or _"draft a welcome email"_
 
 All tools accept an optional **`file_name`** parameter. When provided, the output file will use that name (without extension) instead of a randomly generated identifier.
 
+All tools also accept an optional **`add_unique_prefix`** parameter (default `false`). When `false`, filenames are clean without UUID prefix (e.g., `My_Report.docx`). When `true`, adds an 8-character UUID prefix for server-side uniqueness (e.g., `ff8ae81d_My_Report.docx`). In most cases, the default is sufficient because LibreChat adds its own UUID prefix during file storage.
+
 **Bonus — Dynamic Templates:**
 
 - 📧 **Reusable Email Templates** — Define parameterized email layouts in YAML. Each becomes its own tool with typed arguments (e.g., `first_name`, `promo_code`).

--- a/config.py
+++ b/config.py
@@ -213,6 +213,39 @@ class MinioSettings(BaseModel):
         return self
 
 
+class LibreChatSettings(BaseModel):
+    """Configuration for LibreChat file service uploads.
+
+    When UPLOAD_STRATEGY is set to LIBRECHAT, documents are uploaded to
+    LibreChat's service endpoint and returned as MCP file artifacts that
+    appear as attachments in the chat UI.
+
+    Required environment variables:
+    - LIBRECHAT_SERVICE_URL: Full URL to the service files endpoint
+      (e.g., http://api:3080/api/service/files)
+    - LIBRECHAT_SERVICE_TOKEN: Service token for authentication
+      (must match MCP_SERVICE_TOKEN in LibreChat's .env)
+    """
+    service_url: str = Field(description="LibreChat service files endpoint URL")
+    service_token: str = Field(description="Service token for authentication")
+
+    @model_validator(mode="after")
+    def _non_empty(self) -> "LibreChatSettings":
+        """Ensure all required LibreChat fields are non-empty."""
+        missing = [
+            name for name, val in (
+                ("LIBRECHAT_SERVICE_URL", self.service_url),
+                ("LIBRECHAT_SERVICE_TOKEN", self.service_token),
+            ) if not str(val).strip()
+        ]
+        if missing:
+            raise ValueError(f"Missing required LibreChat settings: {', '.join(missing)}")
+        # Normalize values
+        self.service_url = self.service_url.strip().rstrip("/")
+        self.service_token = self.service_token.strip()
+        return self
+
+
 class StorageStrategy(str, Enum):
     """Supported upload backends for produced documents."""
     LOCAL = "LOCAL"
@@ -220,6 +253,7 @@ class StorageStrategy(str, Enum):
     GCS = "GCS"
     AZURE = "AZURE"
     MINIO = "MINIO"
+    LIBRECHAT = "LIBRECHAT"
 
 
 class StorageSettings(BaseModel):
@@ -236,6 +270,7 @@ class StorageSettings(BaseModel):
     gcs: Optional[GCSSettings] = None
     azure: Optional[AzureSettings] = None
     minio: Optional[MinioSettings] = None
+    librechat: Optional[LibreChatSettings] = None
 
     @model_validator(mode="after")
     def validate_strategy_requirements(self) -> "StorageSettings":
@@ -252,6 +287,9 @@ class StorageSettings(BaseModel):
         elif self.strategy == StorageStrategy.MINIO:
             if not self.minio:
                 raise ValueError("MinIO settings are required for MINIO strategy")
+        elif self.strategy == StorageStrategy.LIBRECHAT:
+            if not self.librechat:
+                raise ValueError("LibreChat settings are required for LIBRECHAT strategy")
         return self
 
 
@@ -382,6 +420,7 @@ class Config(BaseModel):
         gcs_settings = None
         azure_settings = None
         minio_settings = None
+        librechat_settings = None
 
         if strategy == StorageStrategy.S3.value:
             s3_settings = S3Settings(
@@ -412,6 +451,11 @@ class Config(BaseModel):
                 verify_ssl=cls._parse_bool(os.environ.get("MINIO_VERIFY_SSL", "true")),
                 path_style=cls._parse_bool(os.environ.get("MINIO_PATH_STYLE", "true")),
             )
+        elif strategy == StorageStrategy.LIBRECHAT.value:
+            librechat_settings = LibreChatSettings(
+                service_url=os.environ.get("LIBRECHAT_SERVICE_URL", ""),
+                service_token=os.environ.get("LIBRECHAT_SERVICE_TOKEN", ""),
+            )
 
         storage_settings = StorageSettings(
             strategy=StorageStrategy(strategy),
@@ -420,6 +464,7 @@ class Config(BaseModel):
             gcs=gcs_settings,
             azure=azure_settings,
             minio=minio_settings,
+            librechat=librechat_settings,
         )
 
         # API key authentication (optional – empty/missing means no auth)

--- a/docx_tools/__init__.py
+++ b/docx_tools/__init__.py
@@ -1,5 +1,4 @@
-from .base_docx_tool import markdown_to_word
+from .base_docx_tool import markdown_to_word, _markdown_to_word_buffer
 from .dynamic_docx_tools import register_docx_template_tools_from_yaml
 
-__all__ = ["markdown_to_word", "register_docx_template_tools_from_yaml"]
-
+__all__ = ["markdown_to_word", "_markdown_to_word_buffer", "register_docx_template_tools_from_yaml"]

--- a/docx_tools/base_docx_tool.py
+++ b/docx_tools/base_docx_tool.py
@@ -68,10 +68,17 @@ def _markdown_to_doc(markdown_content, title=None, author=None, subject=None,
     return doc
 
 
-def markdown_to_word(markdown_content, title=None, author=None, subject=None,
-                     header_text=None, footer_text=None, include_toc=False, file_name=None,
-                     style_map=None):
-    """Convert Markdown to Word document, save to memory and upload."""
+def _markdown_to_word_buffer(markdown_content, title=None, author=None, subject=None,
+                             header_text=None, footer_text=None, include_toc=False,
+                             style_map=None) -> io.BytesIO:
+    """Convert Markdown to Word document and return as BytesIO buffer.
+
+    This function is useful when the caller needs to handle upload separately,
+    such as for LibreChat file artifact uploads.
+
+    Returns:
+        BytesIO buffer containing the Word document (position at start)
+    """
     doc = _markdown_to_doc(
         markdown_content,
         title=title,
@@ -83,18 +90,39 @@ def markdown_to_word(markdown_content, title=None, author=None, subject=None,
         style_map=style_map,
     )
 
-    # Save the document to BytesIO and upload
     try:
         logger.info("Saving Word document to memory buffer")
         file_object = io.BytesIO()
         doc.save(file_object)
         file_object.seek(0)
+        return file_object
+    except Exception as e:
+        logger.error(f"Error saving Word document to buffer: {e}", exc_info=True)
+        raise RuntimeError(f"Error saving Word document: {e}") from e
 
+
+def markdown_to_word(markdown_content, title=None, author=None, subject=None,
+                     header_text=None, footer_text=None, include_toc=False, file_name=None,
+                     style_map=None):
+    """Convert Markdown to Word document, save to memory and upload."""
+    file_object = _markdown_to_word_buffer(
+        markdown_content,
+        title=title,
+        author=author,
+        subject=subject,
+        header_text=header_text,
+        footer_text=footer_text,
+        include_toc=include_toc,
+        style_map=style_map,
+    )
+
+    # Upload the document
+    try:
         result = upload_file(file_object, "docx", filename=file_name)
         file_object.close()
 
         logger.info("Word document uploaded successfully")
         return result
     except Exception as e:
-        logger.error(f"Error saving/uploading Word document: {e}", exc_info=True)
-        raise RuntimeError(f"Error saving/uploading Word document: {e}") from e
+        logger.error(f"Error uploading Word document: {e}", exc_info=True)
+        raise RuntimeError(f"Error uploading Word document: {e}") from e

--- a/docx_tools/dynamic_docx_tools.py
+++ b/docx_tools/dynamic_docx_tools.py
@@ -741,7 +741,12 @@ def _register_single_template(mcp: FastMCP, spec: Dict[str, Any],
                     doc.save(buffer)
                     buffer.seek(0)
 
-                    result = upload_file(buffer, "docx", filename=payload.get("file_name") or _name)
+                    result = upload_file(
+                        buffer,
+                        "docx",
+                        filename=payload.get("file_name") or _name,
+                        add_unique_prefix=payload.get("add_unique_prefix", False),
+                    )
                 finally:
                     buffer.close()
 

--- a/email_tools/__init__.py
+++ b/email_tools/__init__.py
@@ -4,7 +4,6 @@ This package provides functionality to generate EML draft files using
 HTML templates that already include all CSS styling. The primary entry
 point is create_eml.
 """
-from .base_email_tool import create_eml  # re-export for convenience
+from .base_email_tool import create_eml, _create_eml_buffer
 
-__all__ = ["create_eml"]
-
+__all__ = ["create_eml", "_create_eml_buffer"]

--- a/email_tools/base_email_tool.py
+++ b/email_tools/base_email_tool.py
@@ -35,15 +35,20 @@ def _load_template() -> str:
         raise
 
 
-def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="normal", language="cs-CZ", file_name=None):
-    """Create an unsent email draft (EML) using a Mustache HTML template.
+def _create_eml_buffer(to=None, cc=None, bcc=None, re=None, content=None, priority="normal", language="cs-CZ") -> io.BytesIO:
+    """Create an unsent email draft (EML) and return as BytesIO buffer.
+
+    This function is useful when the caller needs to handle upload separately,
+    such as for LibreChat file artifact uploads.
 
     Template variables:
       {{language}}  - inserted into lang attributes (sanitized)
       {{subject}}   - inserted (HTML-escaped) into <title>
       {{{content}}} - raw HTML fragment for email body (caller restricted to allowed tags)
-    """
 
+    Returns:
+        BytesIO buffer containing the EML file (position at start)
+    """
     # Validate priority
     if priority and priority.lower() not in ["low", "normal", "high"]:
         raise ValueError("Priority must be 'low', 'normal', or 'high'")
@@ -53,7 +58,6 @@ def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="norm
     if not re:
         raise ValueError("Email subject is required")
 
-    buffer = None
     try:
         template_html = _load_template()
 
@@ -61,16 +65,15 @@ def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="norm
         safe_language = (language or "").replace('"', '').replace("'", '')
         escaped_subject = html.escape(re or "")
 
-        renderer = pystache.Renderer(escape=lambda u: u)  # We'll manually escape where needed
+        renderer = pystache.Renderer(escape=lambda u: u)
         context = {
-            "language": safe_language,   # safe for attribute insertion
-            "subject": escaped_subject,  # already escaped
-            "content": content,          # inserted unescaped via triple braces {{{content}}}
+            "language": safe_language,
+            "subject": escaped_subject,
+            "content": content,
         }
         complete_html = renderer.render(template_html, context)
 
         msg = MIMEText(complete_html, 'html', 'utf-8')
-        # Ensure proper encoding (base64 avoids quoted-printable soft breaks generating '=')
         if 'Content-Transfer-Encoding' in msg:
             msg.replace_header('Content-Transfer-Encoding', 'base64')
         else:
@@ -103,7 +106,26 @@ def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="norm
         msg_bytes = msg.as_bytes()
         buffer.write(msg_bytes)
         buffer.seek(0)
+        return buffer
+    except Exception as e:
+        logger.error("Failed to create email draft buffer: %s", e, exc_info=True)
+        raise RuntimeError(f"Failed to create email draft: {e}") from e
 
+
+def create_eml(to=None, cc=None, bcc=None, re=None, content=None, priority="normal", language="cs-CZ", file_name=None):
+    """Create an unsent email draft (EML) using a Mustache HTML template.
+
+    Template variables:
+      {{language}}  - inserted into lang attributes (sanitized)
+      {{subject}}   - inserted (HTML-escaped) into <title>
+      {{{content}}} - raw HTML fragment for email body (caller restricted to allowed tags)
+    """
+    buffer = None
+    try:
+        buffer = _create_eml_buffer(
+            to=to, cc=cc, bcc=bcc, re=re,
+            content=content, priority=priority, language=language
+        )
         return upload_file(buffer, "eml", filename=file_name)
     except Exception as e:
         logger.error("Failed to create email draft: %s", e, exc_info=True)

--- a/email_tools/dynamic_email_tools.py
+++ b/email_tools/dynamic_email_tools.py
@@ -213,7 +213,12 @@ def _register_single_email_template(mcp: FastMCP, spec: Dict[str, Any]) -> bool:
                 try:
                     buffer.write(msg.as_bytes())
                     buffer.seek(0)
-                    result = upload_file(buffer, "eml", filename=safe_payload.get("file_name") or safe_payload.get("subject") or _name)
+                    result = upload_file(
+                        buffer,
+                        "eml",
+                        filename=safe_payload.get("file_name") or safe_payload.get("subject") or _name,
+                        add_unique_prefix=safe_payload.get("add_unique_prefix", False),
+                    )
                     metrics.record_call("email", _name)
                     return result
                 except Exception as e:  # pragma: no cover

--- a/librechat_integration.py
+++ b/librechat_integration.py
@@ -1,0 +1,168 @@
+"""LibreChat integration helpers for MCP tools.
+
+This module provides utilities for extracting user context from request headers
+and formatting responses as MCP file artifacts for LibreChat integration.
+"""
+
+import io
+import logging
+from typing import Optional, Union
+
+from upload_tools import upload_file_async, is_librechat_strategy
+from upload_tools.backends.librechat import format_file_artifact, get_mime_type
+
+logger = logging.getLogger(__name__)
+
+
+def extract_user_context_from_request() -> dict:
+    """Extract user context from the current HTTP request.
+
+    LibreChat sends user information via HTTP headers:
+    - X-User-Id: Required - LibreChat user ID
+    - X-User-Email: Optional - User email
+    - X-Conversation-Id: Optional - Current conversation ID
+
+    Uses FastMCP's get_http_request() to access the current request.
+
+    Returns:
+        Dict with user_id, user_email, and conversation_id (may be None)
+    """
+    try:
+        from fastmcp.server.dependencies import get_http_request
+        request = get_http_request()
+        
+        # Access headers from Starlette Request object
+        headers = request.headers if request else {}
+        
+        return {
+            "user_id": headers.get("x-user-id"),
+            "user_email": headers.get("x-user-email"),
+            "conversation_id": headers.get("x-conversation-id"),
+        }
+    except RuntimeError as e:
+        # No active HTTP request found
+        logger.warning("Could not extract user context: %s", e)
+        return {
+            "user_id": None,
+            "user_email": None,
+            "conversation_id": None,
+        }
+    except ImportError:
+        logger.warning("FastMCP dependencies not available")
+        return {
+            "user_id": None,
+            "user_email": None,
+            "conversation_id": None,
+        }
+
+
+def extract_user_context(ctx=None) -> dict:
+    """Extract user context from FastMCP Context or current HTTP request.
+
+    This function tries multiple methods to get user context:
+    1. From FastMCP Context's request_context (if ctx provided)
+    2. From get_http_request() (fallback)
+
+    LibreChat sends user information via HTTP headers:
+    - X-User-Id: Required - LibreChat user ID
+    - X-User-Email: Optional - User email
+    - X-Conversation-Id: Optional - Current conversation ID
+
+    Args:
+        ctx: Optional FastMCP Context object
+
+    Returns:
+        Dict with user_id, user_email, and conversation_id (may be None)
+    """
+    # Try to get headers from Context first
+    if ctx is not None:
+        try:
+            # Try request_context.request.headers
+            if hasattr(ctx, "request_context") and ctx.request_context:
+                rc = ctx.request_context
+                if hasattr(rc, "request") and rc.request:
+                    headers = rc.request.headers if hasattr(rc.request, "headers") else {}
+                    return {
+                        "user_id": headers.get("x-user-id"),
+                        "user_email": headers.get("x-user-email"),
+                        "conversation_id": headers.get("x-conversation-id"),
+                    }
+        except Exception as e:
+            logger.debug("Could not get headers from Context: %s", e)
+
+    # Fallback to get_http_request()
+    return extract_user_context_from_request()
+
+
+async def upload_and_format_response(
+    file_buffer: io.BytesIO,
+    suffix: str,
+    filename: Optional[str],
+    user_context: dict,
+    success_message: str,
+) -> Union[str, dict]:
+    """Upload a file and format the response appropriately.
+
+    For LIBRECHAT strategy, uploads to LibreChat and returns file artifact format.
+    For other strategies, returns the URL string.
+
+    Args:
+        file_buffer: BytesIO containing the file data
+        suffix: File extension without dot (e.g., 'docx', 'xlsx')
+        filename: Human-readable filename (without extension) or None
+        user_context: Dict from extract_user_context()
+        success_message: Message to include in file artifact response
+
+    Returns:
+        str (URL) for traditional backends, or dict (file artifact) for LIBRECHAT
+    """
+    if is_librechat_strategy():
+        # Validate user context for LIBRECHAT
+        if not user_context.get("user_id"):
+            raise ValueError(
+                "LibreChat upload requires X-User-Id header. "
+                "Ensure LibreChat is configured to send user headers to MCP server."
+            )
+
+        # Upload to LibreChat
+        file_info = await upload_file_async(
+            file_buffer,
+            suffix,
+            filename=filename,
+            user_context=user_context,
+        )
+
+        # Format as MCP file artifact
+        return format_file_artifact(file_info, success_message)
+    else:
+        # Traditional upload - returns URL string
+        from upload_tools import upload_file
+        return upload_file(file_buffer, suffix, filename=filename)
+
+
+def create_file_artifact_response(
+    file_info: dict,
+    text_message: str,
+) -> dict:
+    """Create an MCP file artifact response.
+
+    Args:
+        file_info: Dict with file_id, filename, type, bytes, etc.
+        text_message: Text message to include
+
+    Returns:
+        MCP response dict with content array
+    """
+    return format_file_artifact(file_info, text_message)
+
+
+def get_document_mime_type(suffix: str) -> str:
+    """Get MIME type for a document extension.
+
+    Args:
+        suffix: File extension without dot (e.g., 'docx', 'xlsx')
+
+    Returns:
+        MIME type string
+    """
+    return get_mime_type(f"file.{suffix}")

--- a/main.py
+++ b/main.py
@@ -1,21 +1,24 @@
-from typing import Annotated, List, Optional, Literal
+from typing import Annotated, List, Optional, Literal, Union
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from pydantic import Field
-from xlsx_tools import markdown_to_excel
-from docx_tools import markdown_to_word
+from xlsx_tools import markdown_to_excel, _markdown_to_excel_buffer
+from docx_tools import markdown_to_word, _markdown_to_word_buffer
 from docx_tools.dynamic_docx_tools import register_docx_template_tools_from_yaml
-from pptx_tools import create_presentation
-from email_tools import create_eml
+from pptx_tools import create_presentation, _create_presentation_buffer
+from email_tools import create_eml, _create_eml_buffer
 from email_tools.dynamic_email_tools import register_email_template_tools_from_yaml
 from pathlib import Path
-from config import get_config
-from xml_tools import create_xml_file
+from config import get_config, StorageStrategy
+from xml_tools import create_xml_file, _create_xml_buffer
 from middleware import ApiKeyAuthMiddleware
 from async_runner import run_blocking
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
+from upload_tools import is_librechat_strategy, upload_file_async
+from librechat_integration import extract_user_context_from_request
+from upload_tools.backends.librechat import format_file_artifact
 
 import logging
 mcp = FastMCP("MCP Office Documents")
@@ -149,17 +152,48 @@ async def create_excel_document(
     markdown_content: Annotated[str, Field(description="Markdown content containing tables, headers, and formulas. Use '## Sheet: Sheet Name' to create multiple worksheets. Formulas MUST start with '=' prefix (e.g. =SUM(A1:A5), =A1/B1*100). Use T1.B[0] for cross-table references and B[0] for current row references. Use SheetName!T1.B[0] for cross-sheet references (resolves to SheetName!B2 in Excel). ALWAYS use [0], [1], [2] notation, NEVER use absolute row numbers like B2, B3. Do NOT count table header as first row, first row has index [0]. Supports cell formatting: **bold**, *italic*. Supports column alignment via separator row: |:---|  left, |:---:| center, |---:| right. Dates are auto-detected and formatted (ISO, European, US formats). Supports HTML comment directives placed on a line directly above a table: '<!-- freeze -->' freezes the header row so it stays visible when scrolling; '<!-- types: text, currency:$, date, bool, number, percent -->' forces column data types per column (comma-separated, one per column; omit or leave blank for auto-detection). Type options: 'text' keeps value as-is (preserves leading zeros), 'currency:<symbol>' strips symbol and stores as number with currency format (symbols: $, €, £, ¥, Kč, zł, kr, CHF, R$, ₹), 'date' or 'date:<format>' parses date with optional Excel format, 'bool' maps true/false/yes/no to Excel boolean, 'number' or 'number:<format>' ensures numeric with optional format, 'percent' converts '50%' to 0.5 with percentage format. Multiple directives can be stacked above the same table.")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
     auto_filter: Annotated[bool, Field(description="If true, adds Excel auto-filter dropdowns to table headers, enabling sorting and filtering in Excel.", default=False)] = False,
-) -> str:
+) -> Union[str, dict]:
     """
     Converts markdown to Excel with advanced formula support.
+
+    Returns:
+        For traditional upload strategies: URL string
+        For LIBRECHAT strategy: MCP file artifact dict
     """
 
     logger.info("Converting markdown to Excel document")
 
     try:
-        result = await run_blocking(markdown_to_excel, markdown_content, file_name=file_name, auto_filter=auto_filter)
-        logger.info("Excel document uploaded successfully")
-        return result
+        if is_librechat_strategy():
+            # LibreChat mode: create buffer, upload to LibreChat, return file artifact
+            user_context = extract_user_context_from_request()
+            
+            # Generate document buffer
+            file_buffer = await run_blocking(
+                _markdown_to_excel_buffer,
+                markdown_content,
+                auto_filter=auto_filter,
+            )
+            
+            # Upload to LibreChat
+            file_info = await upload_file_async(
+                file_buffer,
+                "xlsx",
+                filename=file_name,
+                user_context=user_context,
+            )
+            file_buffer.close()
+            
+            logger.info("Excel document uploaded to LibreChat successfully")
+            return format_file_artifact(
+                file_info,
+                f"Excel spreadsheet '{file_name or 'spreadsheet'}' created successfully."
+            )
+        else:
+            # Traditional mode: use existing upload logic
+            result = await run_blocking(markdown_to_excel, markdown_content, file_name=file_name, auto_filter=auto_filter)
+            logger.info("Excel document uploaded successfully")
+            return result
     except Exception as e:
         logger.error(f"Error creating Excel document: {e}", exc_info=True)
         raise ToolError(f"Error creating Excel document: {e}")
@@ -218,28 +252,63 @@ async def create_word_document(
     footer_text: Annotated[Optional[str], Field(description="Text for document footer (bottom of every page). Use {page} for auto page number, {pages} for total pages.", default=None)] = None,
     include_toc: Annotated[Optional[bool], Field(description="If true, inserts a Table of Contents at the beginning of the document. The TOC updates automatically when opened in Word.", default=False)] = False,
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
-) -> str:
+) -> Union[str, dict]:
     """
     Converts markdown to professionally formatted Word document.
 
+    Returns:
+        For traditional upload strategies: URL string
+        For LIBRECHAT strategy: MCP file artifact dict
     """
 
     logger.info("Converting markdown to Word document")
 
     try:
-        result = await run_blocking(
-            markdown_to_word,
-            markdown_content,
-            title=title,
-            author=author,
-            subject=subject,
-            header_text=header_text,
-            footer_text=footer_text,
-            include_toc=include_toc or False,
-            file_name=file_name,
-        )
-        logger.info("Word document uploaded successfully")
-        return result
+        if is_librechat_strategy():
+            # LibreChat mode: create buffer, upload to LibreChat, return file artifact
+            user_context = extract_user_context_from_request()
+            
+            # Generate document buffer
+            file_buffer = await run_blocking(
+                _markdown_to_word_buffer,
+                markdown_content,
+                title=title,
+                author=author,
+                subject=subject,
+                header_text=header_text,
+                footer_text=footer_text,
+                include_toc=include_toc or False,
+            )
+            
+            # Upload to LibreChat
+            file_info = await upload_file_async(
+                file_buffer,
+                "docx",
+                filename=file_name,
+                user_context=user_context,
+            )
+            file_buffer.close()
+            
+            logger.info("Word document uploaded to LibreChat successfully")
+            return format_file_artifact(
+                file_info,
+                f"Word document '{title or file_name or 'document'}' created successfully."
+            )
+        else:
+            # Traditional mode: use existing upload logic
+            result = await run_blocking(
+                markdown_to_word,
+                markdown_content,
+                title=title,
+                author=author,
+                subject=subject,
+                header_text=header_text,
+                footer_text=footer_text,
+                include_toc=include_toc or False,
+                file_name=file_name,
+            )
+            logger.info("Word document uploaded successfully")
+            return result
     except Exception as e:
         logger.error(f"Error creating Word document: {e}", exc_info=True)
         raise ToolError(f"Error creating Word document: {e}")
@@ -275,21 +344,55 @@ Inline markdown formatting is supported in text fields (slide_text, quote_text, 
     footer_text: Annotated[Optional[str], Field(description="Footer text displayed on every slide (e.g., company name, confidentiality notice).", default=None)] = None,
     show_slide_numbers: Annotated[bool, Field(description="Show slide numbers on every slide.", default=False)] = False,
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
-) -> str:
-    """Creates PowerPoint presentations with structured slide models and professional templates."""
+) -> Union[str, dict]:
+    """Creates PowerPoint presentations with structured slide models and professional templates.
+
+    Returns:
+        For traditional upload strategies: URL string
+        For LIBRECHAT strategy: MCP file artifact dict
+    """
 
     logger.info(f"Creating PowerPoint presentation with {len(slides)} slides in {format} format")
 
     try:
-        result = await run_blocking(
-            create_presentation, slides, format,
-            file_name=file_name,
-            author=author,
-            footer_text=footer_text,
-            show_slide_numbers=show_slide_numbers,
-        )
-        logger.info(f"PowerPoint presentation created: {result}")
-        return result
+        if is_librechat_strategy():
+            # LibreChat mode: create buffer, upload to LibreChat, return file artifact
+            user_context = extract_user_context_from_request()
+            
+            # Generate presentation buffer
+            file_buffer = await run_blocking(
+                _create_presentation_buffer,
+                slides, format,
+                author=author,
+                footer_text=footer_text,
+                show_slide_numbers=show_slide_numbers,
+            )
+            
+            # Upload to LibreChat
+            file_info = await upload_file_async(
+                file_buffer,
+                "pptx",
+                filename=file_name,
+                user_context=user_context,
+            )
+            file_buffer.close()
+            
+            logger.info("PowerPoint presentation uploaded to LibreChat successfully")
+            return format_file_artifact(
+                file_info,
+                f"PowerPoint presentation '{file_name or 'presentation'}' with {len(slides)} slides created successfully."
+            )
+        else:
+            # Traditional mode: use existing upload logic
+            result = await run_blocking(
+                create_presentation, slides, format,
+                file_name=file_name,
+                author=author,
+                footer_text=footer_text,
+                show_slide_numbers=show_slide_numbers,
+            )
+            logger.info(f"PowerPoint presentation created: {result}")
+            return result
     except Exception as e:
         logger.error(f"Error creating PowerPoint presentation: {e}", exc_info=True)
         raise ToolError(f"Error creating PowerPoint presentation: {e}")
@@ -309,27 +412,63 @@ async def create_email_draft(
     priority: Annotated[str, Field(description="Email priority: 'low', 'normal', or 'high'", default="normal")],
     language: Annotated[str, Field(description="Language code for proofreading in Outlook (e.g., 'cs-CZ' for Czech, 'en-US' for English, 'de-DE' for German, 'sk-SK' for Slovak)", default="cs-CZ")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
-) -> str:
+) -> Union[str, dict]:
     """
     Creates professional email drafts in EML format with preset styling and language settings.
+
+    Returns:
+        For traditional upload strategies: URL string
+        For LIBRECHAT strategy: MCP file artifact dict
     """
 
     logger.info(f"Creating email draft with subject: {subject}")
 
     try:
-        result = await run_blocking(
-            create_eml,
-            to=to,
-            cc=cc,
-            bcc=bcc,
-            re=subject,
-            content=content,
-            priority=priority,
-            language=language,
-            file_name=file_name,
-        )
-        logger.info(f"Email draft created: {result}")
-        return result
+        if is_librechat_strategy():
+            # LibreChat mode: create buffer, upload to LibreChat, return file artifact
+            user_context = extract_user_context_from_request()
+            
+            # Generate email buffer
+            file_buffer = await run_blocking(
+                _create_eml_buffer,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                re=subject,
+                content=content,
+                priority=priority,
+                language=language,
+            )
+            
+            # Upload to LibreChat
+            file_info = await upload_file_async(
+                file_buffer,
+                "eml",
+                filename=file_name,
+                user_context=user_context,
+            )
+            file_buffer.close()
+            
+            logger.info("Email draft uploaded to LibreChat successfully")
+            return format_file_artifact(
+                file_info,
+                f"Email draft '{subject}' created successfully."
+            )
+        else:
+            # Traditional mode: use existing upload logic
+            result = await run_blocking(
+                create_eml,
+                to=to,
+                cc=cc,
+                bcc=bcc,
+                re=subject,
+                content=content,
+                priority=priority,
+                language=language,
+                file_name=file_name,
+            )
+            logger.info(f"Email draft created: {result}")
+            return result
     except Exception as e:
         logger.error(f"Error creating email draft: {e}", exc_info=True)
         raise ToolError(f"Error creating email draft: {e}")
@@ -343,18 +482,48 @@ async def create_email_draft(
 async def create_xml_document(
     xml_content: Annotated[str, Field(description="Complete, well-formed XML content. Must be valid XML with proper opening and closing tags.")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
-) -> str:
+) -> Union[str, dict]:
     """
     Creates an XML file from provided XML content.
     Validates that the XML is well-formed before saving.
+
+    Returns:
+        For traditional upload strategies: URL string
+        For LIBRECHAT strategy: MCP file artifact dict
     """
 
     logger.info("Creating XML file")
 
     try:
-        result = await run_blocking(create_xml_file, xml_content, file_name=file_name)
-        logger.info("XML file created successfully.")
-        return result
+        if is_librechat_strategy():
+            # LibreChat mode: create buffer, upload to LibreChat, return file artifact
+            user_context = extract_user_context_from_request()
+            
+            # Generate XML buffer
+            file_buffer = await run_blocking(
+                _create_xml_buffer,
+                xml_content,
+            )
+            
+            # Upload to LibreChat
+            file_info = await upload_file_async(
+                file_buffer,
+                "xml",
+                filename=file_name,
+                user_context=user_context,
+            )
+            file_buffer.close()
+            
+            logger.info("XML file uploaded to LibreChat successfully")
+            return format_file_artifact(
+                file_info,
+                f"XML file '{file_name or 'document'}' created successfully."
+            )
+        else:
+            # Traditional mode: use existing upload logic
+            result = await run_blocking(create_xml_file, xml_content, file_name=file_name)
+            logger.info("XML file created successfully.")
+            return result
     except Exception as e:
         logger.error(f"Error creating XML file: {e}", exc_info=True)
         raise ToolError(f"Error creating XML file: {e}")

--- a/main.py
+++ b/main.py
@@ -152,6 +152,7 @@ async def create_excel_document(
     markdown_content: Annotated[str, Field(description="Markdown content containing tables, headers, and formulas. Use '## Sheet: Sheet Name' to create multiple worksheets. Formulas MUST start with '=' prefix (e.g. =SUM(A1:A5), =A1/B1*100). Use T1.B[0] for cross-table references and B[0] for current row references. Use SheetName!T1.B[0] for cross-sheet references (resolves to SheetName!B2 in Excel). ALWAYS use [0], [1], [2] notation, NEVER use absolute row numbers like B2, B3. Do NOT count table header as first row, first row has index [0]. Supports cell formatting: **bold**, *italic*. Supports column alignment via separator row: |:---|  left, |:---:| center, |---:| right. Dates are auto-detected and formatted (ISO, European, US formats). Supports HTML comment directives placed on a line directly above a table: '<!-- freeze -->' freezes the header row so it stays visible when scrolling; '<!-- types: text, currency:$, date, bool, number, percent -->' forces column data types per column (comma-separated, one per column; omit or leave blank for auto-detection). Type options: 'text' keeps value as-is (preserves leading zeros), 'currency:<symbol>' strips symbol and stores as number with currency format (symbols: $, €, £, ¥, Kč, zł, kr, CHF, R$, ₹), 'date' or 'date:<format>' parses date with optional Excel format, 'bool' maps true/false/yes/no to Excel boolean, 'number' or 'number:<format>' ensures numeric with optional format, 'percent' converts '50%' to 0.5 with percentage format. Multiple directives can be stacked above the same table.")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
     auto_filter: Annotated[bool, Field(description="If true, adds Excel auto-filter dropdowns to table headers, enabling sorting and filtering in Excel.", default=False)] = False,
+    add_unique_prefix: Annotated[bool, Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. Default false - LibreChat handles uniqueness with its own UUID prefix.", default=False)] = False,
 ) -> Union[str, dict]:
     """
     Converts markdown to Excel with advanced formula support.
@@ -181,6 +182,7 @@ async def create_excel_document(
                 "xlsx",
                 filename=file_name,
                 user_context=user_context,
+                add_unique_prefix=add_unique_prefix,
             )
             file_buffer.close()
             
@@ -252,6 +254,7 @@ async def create_word_document(
     footer_text: Annotated[Optional[str], Field(description="Text for document footer (bottom of every page). Use {page} for auto page number, {pages} for total pages.", default=None)] = None,
     include_toc: Annotated[Optional[bool], Field(description="If true, inserts a Table of Contents at the beginning of the document. The TOC updates automatically when opened in Word.", default=False)] = False,
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
+    add_unique_prefix: Annotated[bool, Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. Default false - LibreChat handles uniqueness with its own UUID prefix.", default=False)] = False,
 ) -> Union[str, dict]:
     """
     Converts markdown to professionally formatted Word document.
@@ -286,6 +289,7 @@ async def create_word_document(
                 "docx",
                 filename=file_name,
                 user_context=user_context,
+                add_unique_prefix=add_unique_prefix,
             )
             file_buffer.close()
             
@@ -344,6 +348,7 @@ Inline markdown formatting is supported in text fields (slide_text, quote_text, 
     footer_text: Annotated[Optional[str], Field(description="Footer text displayed on every slide (e.g., company name, confidentiality notice).", default=None)] = None,
     show_slide_numbers: Annotated[bool, Field(description="Show slide numbers on every slide.", default=False)] = False,
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
+    add_unique_prefix: Annotated[bool, Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. Default false - LibreChat handles uniqueness with its own UUID prefix.", default=False)] = False,
 ) -> Union[str, dict]:
     """Creates PowerPoint presentations with structured slide models and professional templates.
 
@@ -374,6 +379,7 @@ Inline markdown formatting is supported in text fields (slide_text, quote_text, 
                 "pptx",
                 filename=file_name,
                 user_context=user_context,
+                add_unique_prefix=add_unique_prefix,
             )
             file_buffer.close()
             
@@ -412,6 +418,7 @@ async def create_email_draft(
     priority: Annotated[str, Field(description="Email priority: 'low', 'normal', or 'high'", default="normal")],
     language: Annotated[str, Field(description="Language code for proofreading in Outlook (e.g., 'cs-CZ' for Czech, 'en-US' for English, 'de-DE' for German, 'sk-SK' for Slovak)", default="cs-CZ")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
+    add_unique_prefix: Annotated[bool, Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. Default false - LibreChat handles uniqueness with its own UUID prefix.", default=False)] = False,
 ) -> Union[str, dict]:
     """
     Creates professional email drafts in EML format with preset styling and language settings.
@@ -446,6 +453,7 @@ async def create_email_draft(
                 "eml",
                 filename=file_name,
                 user_context=user_context,
+                add_unique_prefix=add_unique_prefix,
             )
             file_buffer.close()
             
@@ -482,6 +490,7 @@ async def create_email_draft(
 async def create_xml_document(
     xml_content: Annotated[str, Field(description="Complete, well-formed XML content. Must be valid XML with proper opening and closing tags.")],
     file_name: Annotated[Optional[str], Field(description="Custom filename for the output file (without extension). If not provided, a unique identifier will be used.", default=None)] = None,
+    add_unique_prefix: Annotated[bool, Field(description="If true, adds 8-char UUID prefix to filename for uniqueness. Default false - LibreChat handles uniqueness with its own UUID prefix.", default=False)] = False,
 ) -> Union[str, dict]:
     """
     Creates an XML file from provided XML content.
@@ -511,6 +520,7 @@ async def create_xml_document(
                 "xml",
                 filename=file_name,
                 user_context=user_context,
+                add_unique_prefix=add_unique_prefix,
             )
             file_buffer.close()
             

--- a/pptx_tools/__init__.py
+++ b/pptx_tools/__init__.py
@@ -1,10 +1,11 @@
-from .base_pptx_tool import create_presentation
+from .base_pptx_tool import create_presentation, _create_presentation_buffer
 from .slide_builder import PowerpointPresentation
 from .image_utils import download_image, ImageDownloadError, ImageValidationError
 from .chart_utils import add_chart_to_slide, CHART_TYPE_MAP, ChartDataError
 
 __all__ = [
     "create_presentation",
+    "_create_presentation_buffer",
     "PowerpointPresentation",
     "download_image",
     "ImageDownloadError",

--- a/pptx_tools/base_pptx_tool.py
+++ b/pptx_tools/base_pptx_tool.py
@@ -7,6 +7,42 @@ from .slide_builder import PowerpointPresentation
 logger = logging.getLogger(__name__)
 
 
+import io
+
+
+def _create_presentation_buffer(
+    slides: List[Dict[str, Any]],
+    format: str = "4:3",
+    author: Optional[str] = None,
+    footer_text: Optional[str] = None,
+    show_slide_numbers: bool = False,
+) -> io.BytesIO:
+    """Create a PowerPoint presentation and return as BytesIO buffer.
+
+    This function is useful when the caller needs to handle upload separately,
+    such as for LibreChat file artifact uploads.
+
+    :param slides: List of slide dicts with keys based on slide_type
+    :param format: "4:3" or "16:9"
+    :param author: Author name for document properties
+    :param footer_text: Optional footer text displayed on all slides
+    :param show_slide_numbers: Whether to show slide numbers
+    :return: BytesIO buffer containing the PowerPoint file (position at start)
+    """
+    if not slides:
+        raise ValueError("No slides provided")
+
+    logger.info(f"Starting _create_presentation_buffer: slides={len(slides)}, format={format}")
+
+    presentation = PowerpointPresentation(
+        slides, format,
+        author=author,
+        footer_text=footer_text,
+        show_slide_numbers=show_slide_numbers,
+    )
+    return presentation.save()
+
+
 def create_presentation(
     slides: List[Dict[str, Any]],
     format: str = "4:3",
@@ -25,18 +61,12 @@ def create_presentation(
     :param show_slide_numbers: Whether to show slide numbers
     :return: Upload status or URL text
     """
-    if not slides:
-        raise ValueError("No slides provided")
-
-    logger.info(f"Starting create_presentation: slides={len(slides)}, format={format}")
-
-    presentation = PowerpointPresentation(
+    file_object = _create_presentation_buffer(
         slides, format,
         author=author,
         footer_text=footer_text,
         show_slide_numbers=show_slide_numbers,
     )
-    file_object = presentation.save()
 
     try:
         text = upload_file(file_object, "pptx", filename=file_name)

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,7 +119,7 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message."""
+        """Test format_file_artifact with text message returns formatted string."""
         from upload_tools.backends.librechat import format_file_artifact
 
         file_info = {
@@ -129,23 +129,21 @@ class TestLibreChatBackend:
             "type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "bytes": 12345,
             "source": "local",
+            "download_url": "/api/files/download/user-123/test-file-id-123",
         }
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        assert "content" in result
-        assert len(result["content"]) == 2
-
-        text_content = result["content"][0]
-        assert text_content["type"] == "text"
-        assert text_content["text"] == "Document created successfully."
-
-        file_content = result["content"][1]
-        assert file_content["type"] == "file"
-        assert file_content["file_id"] == "test-file-id-123"
-        assert file_content["filename"] == "document.docx"
-        assert file_content["mimeType"] == \
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        # Result should be a string, not a dict
+        assert isinstance(result, str)
+        # Check that text message is included
+        assert "Document created successfully." in result
+        # Check file details are included
+        assert "document.docx" in result
+        assert "test-file-id-123" in result
+        assert "12,345 bytes" in result
+        # Check download URL is included as a Markdown link
+        assert "[document.docx](/api/files/download/user-123/test-file-id-123)" in result
 
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message."""
@@ -159,12 +157,13 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        assert "content" in result
-        assert len(result["content"]) == 1
-
-        file_content = result["content"][0]
-        assert file_content["type"] == "file"
-        assert file_content["file_id"] == "test-file-id-456"
+        # Result should be a string
+        assert isinstance(result, str)
+        # Check file details are included
+        assert "data.xlsx" in result
+        assert "test-file-id-456" in result
+        # Without download_url, no download link should be present
+        assert "Download Link" not in result
 
 
 class TestUploadToLibreChat:
@@ -240,6 +239,8 @@ class TestUploadToLibreChat:
 
             assert result["file_id"] == "uploaded-file-id"
             assert result["filename"] == "document.docx"
+            # Verify download_url is constructed correctly
+            assert result["download_url"] == "/api/files/download/user-123/uploaded-file-id"
 
 
 class TestBufferFunctions:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,7 +119,7 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns two-tuple."""
+        """Test format_file_artifact with text message returns (text, artifacts) tuple."""
         from upload_tools.backends.librechat import format_file_artifact
 
         file_info = {
@@ -134,36 +134,30 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be a two-tuple (content, artifacts)
+        # Result should be a two-tuple (text_string, artifacts_dict)
         assert isinstance(result, tuple)
         assert len(result) == 2
 
-        content, artifacts = result
+        text, artifacts = result
 
-        # Check content list has text and file items
-        assert isinstance(content, list)
-        assert len(content) == 2
-        # First item is text
-        assert content[0]["type"] == "text"
-        assert content[0]["text"] == "Document created successfully."
-        # Second item is file artifact
-        assert content[1]["type"] == "file"
-        assert content[1]["file_id"] == "test-file-id-123"
-        assert content[1]["filename"] == "document.docx"
-        assert content[1]["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        assert content[1]["bytes"] == 12345
-        assert content[1]["source"] == "local"
+        # First element should be the text message string
+        assert isinstance(text, str)
+        assert text == "Document created successfully."
 
-        # Check artifacts object
+        # Second element should be artifacts dict with files array
         assert isinstance(artifacts, dict)
         assert "files" in artifacts
-        assert "file_ids" in artifacts
         assert len(artifacts["files"]) == 1
-        assert artifacts["file_ids"] == ["test-file-id-123"]
-        assert artifacts["files"][0]["file_id"] == "test-file-id-123"
+        file_artifact = artifacts["files"][0]
+        assert file_artifact["file_id"] == "test-file-id-123"
+        assert file_artifact["filename"] == "document.docx"
+        assert file_artifact["filepath"] == "/uploads/document.docx"
+        assert file_artifact["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert file_artifact["bytes"] == 12345
+        assert file_artifact["source"] == "local"
 
     def test_format_file_artifact_without_text(self):
-        """Test format_file_artifact without text message."""
+        """Test format_file_artifact without text message uses default message."""
         from upload_tools.backends.librechat import format_file_artifact
 
         file_info = {
@@ -178,19 +172,18 @@ class TestLibreChatBackend:
         assert isinstance(result, tuple)
         assert len(result) == 2
 
-        content, artifacts = result
+        text, artifacts = result
 
-        # Check content list has only file item (no text)
-        assert isinstance(content, list)
-        assert len(content) == 1
-        # Only item is file artifact
-        assert content[0]["type"] == "file"
-        assert content[0]["file_id"] == "test-file-id-456"
-        assert content[0]["filename"] == "data.xlsx"
+        # First element should be default text message
+        assert isinstance(text, str)
+        assert "data.xlsx" in text  # Default message includes filename
 
-        # Check artifacts object
+        # Second element should be artifacts dict
         assert isinstance(artifacts, dict)
-        assert artifacts["file_ids"] == ["test-file-id-456"]
+        assert "files" in artifacts
+        assert len(artifacts["files"]) == 1
+        assert artifacts["files"][0]["file_id"] == "test-file-id-456"
+        assert artifacts["files"][0]["filename"] == "data.xlsx"
 
 
 class TestUploadToLibreChat:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,8 +119,9 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns CallToolResult."""
+        """Test format_file_artifact with text message returns FastMCP ToolResult."""
         from upload_tools.backends.librechat import format_file_artifact
+        from fastmcp.tools.base import ToolResult
         from mcp import types
 
         file_info = {
@@ -135,19 +136,19 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be CallToolResult
-        assert isinstance(result, types.CallToolResult)
+        # Result should be FastMCP ToolResult
+        assert isinstance(result, ToolResult)
 
         # Check content has TextContent with the message
         assert len(result.content) == 1
         assert isinstance(result.content[0], types.TextContent)
         assert result.content[0].text == "Document created successfully."
 
-        # Check structuredContent has files array
-        assert result.structuredContent is not None
-        assert "files" in result.structuredContent
-        assert len(result.structuredContent["files"]) == 1
-        file_artifact = result.structuredContent["files"][0]
+        # Check structured_content has files array
+        assert result.structured_content is not None
+        assert "files" in result.structured_content
+        assert len(result.structured_content["files"]) == 1
+        file_artifact = result.structured_content["files"][0]
         assert file_artifact["file_id"] == "test-file-id-123"
         assert file_artifact["filename"] == "document.docx"
         assert file_artifact["filepath"] == "/uploads/document.docx"
@@ -158,6 +159,7 @@ class TestLibreChatBackend:
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message uses default message."""
         from upload_tools.backends.librechat import format_file_artifact
+        from fastmcp.tools.base import ToolResult
         from mcp import types
 
         file_info = {
@@ -168,20 +170,20 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        # Result should be CallToolResult
-        assert isinstance(result, types.CallToolResult)
+        # Result should be FastMCP ToolResult
+        assert isinstance(result, ToolResult)
 
         # Check content has default message
         assert len(result.content) == 1
         assert isinstance(result.content[0], types.TextContent)
         assert "data.xlsx" in result.content[0].text  # Default message includes filename
 
-        # Check structuredContent has files array
-        assert result.structuredContent is not None
-        assert "files" in result.structuredContent
-        assert len(result.structuredContent["files"]) == 1
-        assert result.structuredContent["files"][0]["file_id"] == "test-file-id-456"
-        assert result.structuredContent["files"][0]["filename"] == "data.xlsx"
+        # Check structured_content has files array
+        assert result.structured_content is not None
+        assert "files" in result.structured_content
+        assert len(result.structured_content["files"]) == 1
+        assert result.structured_content["files"][0]["file_id"] == "test-file-id-456"
+        assert result.structured_content["files"][0]["filename"] == "data.xlsx"
 
 
 class TestUploadToLibreChat:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,8 +119,9 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns (text, artifacts) tuple."""
+        """Test format_file_artifact with text message returns CallToolResult."""
         from upload_tools.backends.librechat import format_file_artifact
+        from mcp import types
 
         file_info = {
             "file_id": "test-file-id-123",
@@ -134,21 +135,19 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be a two-tuple (text_string, artifacts_dict)
-        assert isinstance(result, tuple)
-        assert len(result) == 2
+        # Result should be CallToolResult
+        assert isinstance(result, types.CallToolResult)
 
-        text, artifacts = result
+        # Check content has TextContent with the message
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], types.TextContent)
+        assert result.content[0].text == "Document created successfully."
 
-        # First element should be the text message string
-        assert isinstance(text, str)
-        assert text == "Document created successfully."
-
-        # Second element should be artifacts dict with files array
-        assert isinstance(artifacts, dict)
-        assert "files" in artifacts
-        assert len(artifacts["files"]) == 1
-        file_artifact = artifacts["files"][0]
+        # Check structuredContent has files array
+        assert result.structuredContent is not None
+        assert "files" in result.structuredContent
+        assert len(result.structuredContent["files"]) == 1
+        file_artifact = result.structuredContent["files"][0]
         assert file_artifact["file_id"] == "test-file-id-123"
         assert file_artifact["filename"] == "document.docx"
         assert file_artifact["filepath"] == "/uploads/document.docx"
@@ -159,6 +158,7 @@ class TestLibreChatBackend:
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message uses default message."""
         from upload_tools.backends.librechat import format_file_artifact
+        from mcp import types
 
         file_info = {
             "file_id": "test-file-id-456",
@@ -168,22 +168,20 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        # Result should be a two-tuple
-        assert isinstance(result, tuple)
-        assert len(result) == 2
+        # Result should be CallToolResult
+        assert isinstance(result, types.CallToolResult)
 
-        text, artifacts = result
+        # Check content has default message
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], types.TextContent)
+        assert "data.xlsx" in result.content[0].text  # Default message includes filename
 
-        # First element should be default text message
-        assert isinstance(text, str)
-        assert "data.xlsx" in text  # Default message includes filename
-
-        # Second element should be artifacts dict
-        assert isinstance(artifacts, dict)
-        assert "files" in artifacts
-        assert len(artifacts["files"]) == 1
-        assert artifacts["files"][0]["file_id"] == "test-file-id-456"
-        assert artifacts["files"][0]["filename"] == "data.xlsx"
+        # Check structuredContent has files array
+        assert result.structuredContent is not None
+        assert "files" in result.structuredContent
+        assert len(result.structuredContent["files"]) == 1
+        assert result.structuredContent["files"][0]["file_id"] == "test-file-id-456"
+        assert result.structuredContent["files"][0]["filename"] == "data.xlsx"
 
 
 class TestUploadToLibreChat:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -1,0 +1,333 @@
+"""Tests for LibreChat file artifacts integration.
+
+These tests verify the LIBRECHAT upload strategy and file artifact formatting.
+"""
+
+import io
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+class TestLibreChatSettings:
+    """Test LibreChatSettings configuration model."""
+
+    def test_librechat_settings_valid(self):
+        """Test valid LibreChat settings."""
+        from config import LibreChatSettings
+
+        settings = LibreChatSettings(
+            service_url="http://api:3080/api/service/files",
+            service_token="test_token_123",
+        )
+        assert settings.service_url == "http://api:3080/api/service/files"
+        assert settings.service_token == "test_token_123"
+
+    def test_librechat_settings_strips_whitespace(self):
+        """Test that LibreChat settings strips whitespace."""
+        from config import LibreChatSettings
+
+        settings = LibreChatSettings(
+            service_url="  http://api:3080/api/service/files/  ",
+            service_token="  test_token  ",
+        )
+        assert settings.service_url == "http://api:3080/api/service/files"
+        assert settings.service_token == "test_token"
+
+    def test_librechat_settings_missing_url_raises(self):
+        """Test that missing service_url raises ValueError."""
+        from config import LibreChatSettings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            LibreChatSettings(
+                service_url="",
+                service_token="test_token",
+            )
+
+    def test_librechat_settings_missing_token_raises(self):
+        """Test that missing service_token raises ValueError."""
+        from config import LibreChatSettings
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            LibreChatSettings(
+                service_url="http://api:3080/api/service/files",
+                service_token="",
+            )
+
+
+class TestStorageStrategy:
+    """Test StorageStrategy enum includes LIBRECHAT."""
+
+    def test_librechat_in_storage_strategy(self):
+        """Test LIBRECHAT is a valid storage strategy."""
+        from config import StorageStrategy
+
+        assert hasattr(StorageStrategy, "LIBRECHAT")
+        assert StorageStrategy.LIBRECHAT.value == "LIBRECHAT"
+
+    def test_all_strategies_present(self):
+        """Test all expected strategies are present."""
+        from config import StorageStrategy
+
+        expected = {"LOCAL", "S3", "GCS", "AZURE", "MINIO", "LIBRECHAT"}
+        actual = {s.value for s in StorageStrategy}
+        assert expected == actual
+
+
+class TestLibreChatBackend:
+    """Test LibreChat upload backend functions."""
+
+    def test_get_mime_type_docx(self):
+        """Test MIME type for docx."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        assert get_mime_type("document.docx") == \
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+    def test_get_mime_type_xlsx(self):
+        """Test MIME type for xlsx."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        assert get_mime_type("spreadsheet.xlsx") == \
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+    def test_get_mime_type_pptx(self):
+        """Test MIME type for pptx."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        assert get_mime_type("presentation.pptx") == \
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+    def test_get_mime_type_eml(self):
+        """Test MIME type for eml."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        assert get_mime_type("email.eml") == "message/rfc822"
+
+    def test_get_mime_type_xml(self):
+        """Test MIME type for xml."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        assert get_mime_type("data.xml") == "application/xml"
+
+    def test_get_mime_type_unknown_fallback(self):
+        """Test MIME type fallback for unknown extension."""
+        from upload_tools.backends.librechat import get_mime_type
+
+        result = get_mime_type("file.unknown123")
+        assert result == "application/octet-stream"
+
+    def test_format_file_artifact_with_text(self):
+        """Test format_file_artifact with text message."""
+        from upload_tools.backends.librechat import format_file_artifact
+
+        file_info = {
+            "file_id": "test-file-id-123",
+            "filename": "document.docx",
+            "filepath": "/uploads/document.docx",
+            "type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "bytes": 12345,
+            "source": "local",
+        }
+
+        result = format_file_artifact(file_info, "Document created successfully.")
+
+        assert "content" in result
+        assert len(result["content"]) == 2
+
+        text_content = result["content"][0]
+        assert text_content["type"] == "text"
+        assert text_content["text"] == "Document created successfully."
+
+        file_content = result["content"][1]
+        assert file_content["type"] == "file"
+        assert file_content["file_id"] == "test-file-id-123"
+        assert file_content["filename"] == "document.docx"
+        assert file_content["mimeType"] == \
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+    def test_format_file_artifact_without_text(self):
+        """Test format_file_artifact without text message."""
+        from upload_tools.backends.librechat import format_file_artifact
+
+        file_info = {
+            "file_id": "test-file-id-456",
+            "filename": "data.xlsx",
+            "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }
+
+        result = format_file_artifact(file_info, None)
+
+        assert "content" in result
+        assert len(result["content"]) == 1
+
+        file_content = result["content"][0]
+        assert file_content["type"] == "file"
+        assert file_content["file_id"] == "test-file-id-456"
+
+
+class TestUploadToLibreChat:
+    """Test upload_to_librechat function."""
+
+    @pytest.mark.asyncio
+    async def test_upload_missing_user_id_raises(self):
+        """Test that missing user_id raises ValueError."""
+        from upload_tools.backends.librechat import upload_to_librechat
+        from config import LibreChatSettings
+
+        config = LibreChatSettings(
+            service_url="http://api:3080/api/service/files",
+            service_token="test_token",
+        )
+
+        file_buffer = io.BytesIO(b"test content")
+        user_context = {"user_id": None}
+
+        with pytest.raises(ValueError, match="user_id"):
+            await upload_to_librechat(
+                file_buffer,
+                "document.docx",
+                user_context,
+                config,
+            )
+
+    @pytest.mark.asyncio
+    async def test_upload_success(self):
+        """Test successful upload to LibreChat."""
+        from upload_tools.backends.librechat import upload_to_librechat
+        from config import LibreChatSettings
+
+        config = LibreChatSettings(
+            service_url="http://api:3080/api/service/files",
+            service_token="test_token",
+        )
+
+        file_buffer = io.BytesIO(b"test content")
+        user_context = {
+            "user_id": "user-123",
+            "user_email": "test@example.com",
+            "conversation_id": "conv-456",
+        }
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "success": True,
+            "file": {
+                "file_id": "uploaded-file-id",
+                "filename": "document.docx",
+                "filepath": "/uploads/document.docx",
+                "type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "bytes": 12,
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("upload_tools.backends.librechat.httpx.AsyncClient") as mock_client:
+            mock_instance = AsyncMock()
+            mock_instance.post = AsyncMock(return_value=mock_response)
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_client.return_value = mock_instance
+
+            result = await upload_to_librechat(
+                file_buffer,
+                "document.docx",
+                user_context,
+                config,
+            )
+
+            assert result["file_id"] == "uploaded-file-id"
+            assert result["filename"] == "document.docx"
+
+
+class TestBufferFunctions:
+    """Test document buffer creation functions."""
+
+    def test_markdown_to_word_buffer(self):
+        """Test _markdown_to_word_buffer returns BytesIO."""
+        from docx_tools import _markdown_to_word_buffer
+
+        result = _markdown_to_word_buffer("# Hello World\n\nThis is a test.")
+
+        assert isinstance(result, io.BytesIO)
+        assert result.tell() == 0
+        content = result.read()
+        assert len(content) > 0
+        result.close()
+
+    def test_markdown_to_excel_buffer(self):
+        """Test _markdown_to_excel_buffer returns BytesIO."""
+        from xlsx_tools import _markdown_to_excel_buffer
+
+        markdown = """| Name | Value |
+|------|-------|
+| A    | 1     |
+| B    | 2     |
+"""
+        result = _markdown_to_excel_buffer(markdown)
+
+        assert isinstance(result, io.BytesIO)
+        assert result.tell() == 0
+        content = result.read()
+        assert len(content) > 0
+        result.close()
+
+    def test_create_presentation_buffer(self):
+        """Test _create_presentation_buffer returns BytesIO."""
+        from pptx_tools import _create_presentation_buffer
+
+        slides = [
+            {"slide_type": "title", "slide_title": "Test Presentation", "subtitle": "Test"}
+        ]
+        result = _create_presentation_buffer(slides)
+
+        assert isinstance(result, io.BytesIO)
+        assert result.tell() == 0
+        content = result.read()
+        assert len(content) > 0
+        result.close()
+
+    def test_create_eml_buffer(self):
+        """Test _create_eml_buffer returns BytesIO."""
+        from email_tools import _create_eml_buffer
+
+        result = _create_eml_buffer(
+            to=["test@example.com"],
+            re="Test Subject",
+            content="<p>Test content</p>",
+        )
+
+        assert isinstance(result, io.BytesIO)
+        assert result.tell() == 0
+        content = result.read()
+        assert len(content) > 0
+        assert b"Test Subject" in content
+        result.close()
+
+    def test_create_xml_buffer(self):
+        """Test _create_xml_buffer returns BytesIO."""
+        from xml_tools import _create_xml_buffer
+
+        xml_content = "<root><item>Test</item></root>"
+        result = _create_xml_buffer(xml_content)
+
+        assert isinstance(result, io.BytesIO)
+        assert result.tell() == 0
+        content = result.read()
+        assert b"<root>" in content
+        result.close()
+
+
+class TestIsLibreChatStrategy:
+    """Test is_librechat_strategy function."""
+
+    def test_is_librechat_strategy_callable(self):
+        """Test is_librechat_strategy is callable."""
+        from upload_tools import is_librechat_strategy
+
+        assert callable(is_librechat_strategy)
+        # Default should be LOCAL, not LIBRECHAT
+        result = is_librechat_strategy()
+        assert isinstance(result, bool)

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,10 +119,8 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns FastMCP ToolResult."""
+        """Test format_file_artifact with text message returns dict with result property."""
         from upload_tools.backends.librechat import format_file_artifact
-        from fastmcp.tools.base import ToolResult
-        from mcp import types
 
         file_info = {
             "file_id": "test-file-id-123",
@@ -136,31 +134,25 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be FastMCP ToolResult
-        assert isinstance(result, ToolResult)
+        # Result should be dict with result property
+        assert isinstance(result, dict)
+        assert "result" in result
 
-        # Check content has TextContent with the message
-        assert len(result.content) == 1
-        assert isinstance(result.content[0], types.TextContent)
-        assert result.content[0].text == "Document created successfully."
+        # Check result.message
+        assert result["result"]["message"] == "Document created successfully."
 
-        # Check structured_content has files array
-        assert result.structured_content is not None
-        assert "files" in result.structured_content
-        assert len(result.structured_content["files"]) == 1
-        file_artifact = result.structured_content["files"][0]
-        assert file_artifact["file_id"] == "test-file-id-123"
-        assert file_artifact["filename"] == "document.docx"
-        assert file_artifact["filepath"] == "/uploads/document.docx"
-        assert file_artifact["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        assert file_artifact["bytes"] == 12345
-        assert file_artifact["source"] == "local"
+        # Check result.file
+        file_data = result["result"]["file"]
+        assert file_data["file_id"] == "test-file-id-123"
+        assert file_data["filename"] == "document.docx"
+        assert file_data["filepath"] == "/uploads/document.docx"
+        assert file_data["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert file_data["bytes"] == 12345
+        assert file_data["source"] == "local"
 
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message uses default message."""
         from upload_tools.backends.librechat import format_file_artifact
-        from fastmcp.tools.base import ToolResult
-        from mcp import types
 
         file_info = {
             "file_id": "test-file-id-456",
@@ -170,20 +162,17 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        # Result should be FastMCP ToolResult
-        assert isinstance(result, ToolResult)
+        # Result should be dict with result property
+        assert isinstance(result, dict)
+        assert "result" in result
 
-        # Check content has default message
-        assert len(result.content) == 1
-        assert isinstance(result.content[0], types.TextContent)
-        assert "data.xlsx" in result.content[0].text  # Default message includes filename
+        # Check result.message has default text including filename
+        assert "data.xlsx" in result["result"]["message"]
 
-        # Check structured_content has files array
-        assert result.structured_content is not None
-        assert "files" in result.structured_content
-        assert len(result.structured_content["files"]) == 1
-        assert result.structured_content["files"][0]["file_id"] == "test-file-id-456"
-        assert result.structured_content["files"][0]["filename"] == "data.xlsx"
+        # Check result.file
+        file_data = result["result"]["file"]
+        assert file_data["file_id"] == "test-file-id-456"
+        assert file_data["filename"] == "data.xlsx"
 
 
 class TestUploadToLibreChat:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,8 +119,9 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns formatted string."""
+        """Test format_file_artifact with text message returns ToolResult."""
         from upload_tools.backends.librechat import format_file_artifact
+        from fastmcp.server.server import ToolResult
 
         file_info = {
             "file_id": "test-file-id-123",
@@ -134,20 +135,28 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be a string, not a dict
-        assert isinstance(result, str)
-        # Check that text message is included
-        assert "Document created successfully." in result
-        # Check file details are included
-        assert "document.docx" in result
-        assert "test-file-id-123" in result
-        assert "12,345 bytes" in result
-        # Check download URL is included as a Markdown link
-        assert "[document.docx](/api/files/download/user-123/test-file-id-123)" in result
+        # Result should be a ToolResult
+        assert isinstance(result, ToolResult)
+        # Check content has text
+        assert len(result.content) == 1
+        assert result.content[0].text == "Document created successfully."
+        # Check structured_content has the file artifact format
+        assert "content" in result.structured_content
+        content_items = result.structured_content["content"]
+        assert len(content_items) == 2
+        # First item is text
+        assert content_items[0]["type"] == "text"
+        assert content_items[0]["text"] == "Document created successfully."
+        # Second item is file artifact
+        assert content_items[1]["type"] == "file"
+        assert content_items[1]["file_id"] == "test-file-id-123"
+        assert content_items[1]["filename"] == "document.docx"
+        assert content_items[1]["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message."""
         from upload_tools.backends.librechat import format_file_artifact
+        from fastmcp.server.server import ToolResult
 
         file_info = {
             "file_id": "test-file-id-456",
@@ -157,13 +166,16 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        # Result should be a string
-        assert isinstance(result, str)
-        # Check file details are included
-        assert "data.xlsx" in result
-        assert "test-file-id-456" in result
-        # Without download_url, no download link should be present
-        assert "Download Link" not in result
+        # Result should be a ToolResult
+        assert isinstance(result, ToolResult)
+        # Check structured_content has only file artifact (no text)
+        assert "content" in result.structured_content
+        content_items = result.structured_content["content"]
+        assert len(content_items) == 1
+        # Only item is file artifact
+        assert content_items[0]["type"] == "file"
+        assert content_items[0]["file_id"] == "test-file-id-456"
+        assert content_items[0]["filename"] == "data.xlsx"
 
 
 class TestUploadToLibreChat:

--- a/tests/test_librechat_integration.py
+++ b/tests/test_librechat_integration.py
@@ -119,9 +119,8 @@ class TestLibreChatBackend:
         assert result == "application/octet-stream"
 
     def test_format_file_artifact_with_text(self):
-        """Test format_file_artifact with text message returns ToolResult."""
+        """Test format_file_artifact with text message returns two-tuple."""
         from upload_tools.backends.librechat import format_file_artifact
-        from fastmcp.server.server import ToolResult
 
         file_info = {
             "file_id": "test-file-id-123",
@@ -135,28 +134,37 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, "Document created successfully.")
 
-        # Result should be a ToolResult
-        assert isinstance(result, ToolResult)
-        # Check content has text
-        assert len(result.content) == 1
-        assert result.content[0].text == "Document created successfully."
-        # Check structured_content has the file artifact format
-        assert "content" in result.structured_content
-        content_items = result.structured_content["content"]
-        assert len(content_items) == 2
+        # Result should be a two-tuple (content, artifacts)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+        content, artifacts = result
+
+        # Check content list has text and file items
+        assert isinstance(content, list)
+        assert len(content) == 2
         # First item is text
-        assert content_items[0]["type"] == "text"
-        assert content_items[0]["text"] == "Document created successfully."
+        assert content[0]["type"] == "text"
+        assert content[0]["text"] == "Document created successfully."
         # Second item is file artifact
-        assert content_items[1]["type"] == "file"
-        assert content_items[1]["file_id"] == "test-file-id-123"
-        assert content_items[1]["filename"] == "document.docx"
-        assert content_items[1]["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert content[1]["type"] == "file"
+        assert content[1]["file_id"] == "test-file-id-123"
+        assert content[1]["filename"] == "document.docx"
+        assert content[1]["mimeType"] == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        assert content[1]["bytes"] == 12345
+        assert content[1]["source"] == "local"
+
+        # Check artifacts object
+        assert isinstance(artifacts, dict)
+        assert "files" in artifacts
+        assert "file_ids" in artifacts
+        assert len(artifacts["files"]) == 1
+        assert artifacts["file_ids"] == ["test-file-id-123"]
+        assert artifacts["files"][0]["file_id"] == "test-file-id-123"
 
     def test_format_file_artifact_without_text(self):
         """Test format_file_artifact without text message."""
         from upload_tools.backends.librechat import format_file_artifact
-        from fastmcp.server.server import ToolResult
 
         file_info = {
             "file_id": "test-file-id-456",
@@ -166,16 +174,23 @@ class TestLibreChatBackend:
 
         result = format_file_artifact(file_info, None)
 
-        # Result should be a ToolResult
-        assert isinstance(result, ToolResult)
-        # Check structured_content has only file artifact (no text)
-        assert "content" in result.structured_content
-        content_items = result.structured_content["content"]
-        assert len(content_items) == 1
+        # Result should be a two-tuple
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+        content, artifacts = result
+
+        # Check content list has only file item (no text)
+        assert isinstance(content, list)
+        assert len(content) == 1
         # Only item is file artifact
-        assert content_items[0]["type"] == "file"
-        assert content_items[0]["file_id"] == "test-file-id-456"
-        assert content_items[0]["filename"] == "data.xlsx"
+        assert content[0]["type"] == "file"
+        assert content[0]["file_id"] == "test-file-id-456"
+        assert content[0]["filename"] == "data.xlsx"
+
+        # Check artifacts object
+        assert isinstance(artifacts, dict)
+        assert artifacts["file_ids"] == ["test-file-id-456"]
 
 
 class TestUploadToLibreChat:

--- a/tests/test_upload_unique_prefix.py
+++ b/tests/test_upload_unique_prefix.py
@@ -1,0 +1,123 @@
+"""Tests for add_unique_prefix parameter in upload_tools.
+
+These tests verify that the add_unique_prefix parameter correctly controls
+whether a UUID prefix is added to filenames during upload.
+"""
+
+import pytest
+from upload_tools.utils import generate_named_object_name
+
+
+def test_generate_named_object_name_without_prefix():
+    """Default behavior: no prefix (add_unique_prefix=False)."""
+    result = generate_named_object_name("My Report", "docx")
+    assert result == "My_Report.docx"
+    # Verify no UUID prefix exists
+    assert not result.startswith(("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"))
+
+
+def test_generate_named_object_name_without_prefix_explicit():
+    """Explicitly pass add_unique_prefix=False."""
+    result = generate_named_object_name("My Report", "docx", add_unique_prefix=False)
+    assert result == "My_Report.docx"
+
+
+def test_generate_named_object_name_with_prefix():
+    """With add_unique_prefix=True: 8-char UUID prefix."""
+    result = generate_named_object_name("My Report", "docx", add_unique_prefix=True)
+    assert result.endswith("_My_Report.docx")
+    # Extract prefix (everything before first underscore)
+    prefix = result.split("_")[0]
+    assert len(prefix) == 8
+    # Verify prefix is hexadecimal
+    assert all(c in "0123456789abcdef" for c in prefix)
+
+
+def test_generate_named_object_name_with_prefix_different_files():
+    """Verify different UUIDs for different calls with same filename."""
+    result1 = generate_named_object_name("document", "xlsx", add_unique_prefix=True)
+    result2 = generate_named_object_name("document", "xlsx", add_unique_prefix=True)
+    
+    # Both should end with same filename
+    assert result1.endswith("_document.xlsx")
+    assert result2.endswith("_document.xlsx")
+    
+    # But prefixes should be different (different UUIDs)
+    prefix1 = result1.split("_")[0]
+    prefix2 = result2.split("_")[0]
+    assert prefix1 != prefix2
+
+
+def test_generate_named_object_name_sanitization():
+    """Sanitization still works with and without prefix."""
+    # Without prefix
+    result = generate_named_object_name("Report: Q1 2024!", "xlsx", add_unique_prefix=False)
+    assert result == "Report_Q1_2024.xlsx"
+    
+    # With prefix
+    result_with_prefix = generate_named_object_name("Report: Q1 2024!", "xlsx", add_unique_prefix=True)
+    assert result_with_prefix.endswith("_Report_Q1_2024.xlsx")
+    prefix = result_with_prefix.split("_")[0]
+    assert len(prefix) == 8
+
+
+def test_generate_named_object_name_special_characters():
+    """Test sanitization of special characters."""
+    # Without prefix
+    result = generate_named_object_name("My@Document#2024", "docx", add_unique_prefix=False)
+    assert result == "MyDocument2024.docx"
+    
+    # With prefix
+    result_with_prefix = generate_named_object_name("My@Document#2024", "docx", add_unique_prefix=True)
+    assert result_with_prefix.endswith("_MyDocument2024.docx")
+
+
+def test_generate_named_object_name_different_extensions():
+    """Test with different file extensions."""
+    extensions = ["docx", "xlsx", "pptx", "eml", "xml"]
+    
+    for ext in extensions:
+        # Without prefix
+        result = generate_named_object_name("test", ext, add_unique_prefix=False)
+        assert result == f"test.{ext}"
+        
+        # With prefix
+        result_with_prefix = generate_named_object_name("test", ext, add_unique_prefix=True)
+        assert result_with_prefix.endswith(f"_test.{ext}")
+        prefix = result_with_prefix.split("_")[0]
+        assert len(prefix) == 8
+
+
+def test_generate_named_object_name_empty_string():
+    """Test with empty filename (should fallback to 'document')."""
+    # Without prefix
+    result = generate_named_object_name("", "docx", add_unique_prefix=False)
+    assert result == "document.docx"
+    
+    # With prefix
+    result_with_prefix = generate_named_object_name("", "docx", add_unique_prefix=True)
+    assert result_with_prefix.endswith("_document.docx")
+
+
+def test_generate_named_object_name_whitespace_only():
+    """Test with whitespace-only filename (should fallback to 'document')."""
+    # Without prefix
+    result = generate_named_object_name("   ", "xlsx", add_unique_prefix=False)
+    assert result == "document.xlsx"
+    
+    # With prefix
+    result_with_prefix = generate_named_object_name("   ", "xlsx", add_unique_prefix=True)
+    assert result_with_prefix.endswith("_document.xlsx")
+
+
+def test_generate_named_object_name_long_filename():
+    """Test with long filename (should truncate to 100 chars)."""
+    long_name = "a" * 150
+    
+    # Without prefix
+    result = generate_named_object_name(long_name, "docx", add_unique_prefix=False)
+    assert result == f"{long_name[:100]}.docx"
+    
+    # With prefix (truncation happens after prefix)
+    result_with_prefix = generate_named_object_name(long_name, "docx", add_unique_prefix=True)
+    assert result_with_prefix.endswith(f"_{long_name[:100]}.docx")

--- a/upload_tools/__init__.py
+++ b/upload_tools/__init__.py
@@ -1,4 +1,3 @@
-from .main import upload_file
+from .main import upload_file, upload_file_async, is_librechat_strategy
 
-__all__ = ["upload_file"]
-
+__all__ = ["upload_file", "upload_file_async", "is_librechat_strategy"]

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -1,0 +1,231 @@
+"""LibreChat file service upload backend.
+
+This module handles uploading generated documents to LibreChat's service
+endpoint, which stores files and associates them with conversations.
+The uploaded files appear as attachments in the chat UI.
+"""
+
+import io
+import logging
+import mimetypes
+from typing import Optional
+
+import httpx
+
+from config import LibreChatSettings
+
+logger = logging.getLogger(__name__)
+
+# MIME type mapping for document extensions
+MIME_TYPES = {
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "pdf": "application/pdf",
+    "eml": "message/rfc822",
+    "xml": "application/xml",
+    "txt": "text/plain",
+    "md": "text/markdown",
+    "json": "application/json",
+    "csv": "text/csv",
+}
+
+
+def get_mime_type(filename: str) -> str:
+    """Get MIME type for a filename.
+
+    Args:
+        filename: Filename with extension
+
+    Returns:
+        MIME type string
+    """
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext in MIME_TYPES:
+        return MIME_TYPES[ext]
+    # Fallback to mimetypes module
+    mime_type, _ = mimetypes.guess_type(filename)
+    return mime_type or "application/octet-stream"
+
+
+async def upload_to_librechat(
+    file_object: io.BytesIO,
+    filename: str,
+    user_context: dict,
+    config: LibreChatSettings,
+    timeout: float = 60.0,
+) -> dict:
+    """Upload a file to LibreChat's service endpoint.
+
+    This function uploads a file to LibreChat and returns metadata that can
+    be used to construct an MCP file artifact response.
+
+    Args:
+        file_object: BytesIO object containing the file data
+        filename: Name of the file (with extension)
+        user_context: Dict containing user information from request headers:
+            - user_id: Required - LibreChat user ID (from X-User-Id header)
+            - user_email: Optional - User email (from X-User-Email header)
+            - conversation_id: Optional - Conversation ID (from X-Conversation-Id header)
+        config: LibreChatSettings with service_url and service_token
+        timeout: Request timeout in seconds (default 60)
+
+    Returns:
+        Dict with file metadata:
+        {
+            "file_id": "uuid-string",
+            "filename": "document.docx",
+            "filepath": "/path/to/file",
+            "type": "application/vnd.openxmlformats-...",
+            "bytes": 12345,
+            "source": "local"
+        }
+
+    Raises:
+        ValueError: If user_context is missing required user_id
+        RuntimeError: If upload fails
+    """
+    # Validate user context
+    user_id = user_context.get("user_id")
+    if not user_id:
+        raise ValueError(
+            "LibreChat upload requires user_id in user_context. "
+            "Ensure X-User-Id header is passed from LibreChat."
+        )
+
+    # Prepare headers
+    headers = {
+        "X-Service-Token": config.service_token,
+        "X-User-Id": user_id,
+    }
+
+    # Add optional headers
+    if user_context.get("user_email"):
+        headers["X-User-Email"] = user_context["user_email"]
+    if user_context.get("conversation_id"):
+        headers["X-Conversation-Id"] = user_context["conversation_id"]
+
+    # Determine MIME type
+    mime_type = get_mime_type(filename)
+
+    logger.info(
+        "Uploading file to LibreChat: %s (%s) for user %s",
+        filename,
+        mime_type,
+        user_id,
+    )
+
+    # Ensure file object is at the beginning
+    file_object.seek(0)
+    file_size = len(file_object.getvalue())
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            # Prepare multipart form data
+            files = {
+                "file": (filename, file_object, mime_type),
+            }
+            data = {
+                "filename": filename,
+            }
+
+            response = await client.post(
+                config.service_url,
+                headers=headers,
+                files=files,
+                data=data,
+            )
+
+            # Check for errors
+            if response.status_code == 401:
+                raise RuntimeError(
+                    "LibreChat upload failed: Invalid service token. "
+                    "Verify LIBRECHAT_SERVICE_TOKEN matches MCP_SERVICE_TOKEN in LibreChat."
+                )
+            elif response.status_code == 400:
+                error_detail = response.json().get("message", response.text)
+                raise RuntimeError(f"LibreChat upload failed: {error_detail}")
+
+            response.raise_for_status()
+
+            result = response.json()
+
+    except httpx.TimeoutException as e:
+        logger.error("LibreChat upload timeout: %s", e)
+        raise RuntimeError(
+            f"LibreChat upload timed out after {timeout}s. "
+            "Try increasing timeout or check network connectivity."
+        ) from e
+    except httpx.HTTPStatusError as e:
+        logger.error("LibreChat upload HTTP error: %s", e)
+        raise RuntimeError(f"LibreChat upload failed: {e}") from e
+    except httpx.RequestError as e:
+        logger.error("LibreChat upload request error: %s", e)
+        raise RuntimeError(
+            f"LibreChat upload failed: {e}. "
+            f"Check LIBRECHAT_SERVICE_URL ({config.service_url}) is accessible."
+        ) from e
+
+    # Extract file info from response
+    if not result.get("success", False):
+        error_msg = result.get("error") or result.get("message") or "Unknown error"
+        raise RuntimeError(f"LibreChat upload failed: {error_msg}")
+
+    file_info = result.get("file", {})
+    if not file_info.get("file_id"):
+        raise RuntimeError(
+            "LibreChat upload succeeded but response missing file_id. "
+            f"Response: {result}"
+        )
+
+    logger.info(
+        "File uploaded successfully to LibreChat: file_id=%s, filename=%s",
+        file_info.get("file_id"),
+        file_info.get("filename", filename),
+    )
+
+    # Return normalized file metadata
+    return {
+        "file_id": file_info["file_id"],
+        "filename": file_info.get("filename", filename),
+        "filepath": file_info.get("filepath"),
+        "type": file_info.get("type", mime_type),
+        "bytes": file_info.get("bytes", file_size),
+        "source": file_info.get("source", "local"),
+    }
+
+
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> dict:
+    """Format file info as an MCP tool response with file artifact.
+
+    This creates the response structure expected by LibreChat for displaying
+    files as attachments in the chat UI.
+
+    Args:
+        file_info: Dict returned by upload_to_librechat()
+        text_message: Optional text message to include with the file
+
+    Returns:
+        MCP tool response dict with content array containing text and file items
+    """
+    content = []
+
+    # Add text content if provided
+    if text_message:
+        content.append({
+            "type": "text",
+            "text": text_message,
+        })
+
+    # Add file artifact
+    content.append({
+        "type": "file",
+        "file_id": file_info["file_id"],
+        "filename": file_info["filename"],
+        "filepath": file_info.get("filepath"),
+        "mimeType": file_info.get("type"),  # Note: MCP uses mimeType, not type
+        "bytes": file_info.get("bytes"),
+        "source": file_info.get("source", "local"),
+    })
+
+    return {"content": content}

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -202,18 +202,20 @@ async def upload_to_librechat(
 
 
 def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
-    """Format file info as an MCP CallToolResult with file artifact.
+    """Format file info using FastMCP ToolResult with structured_content.
 
-    Returns a CallToolResult directly to bypass FastMCP's response processing.
-    LibreChat will receive the proper MCP format with content and structuredContent.
+    Uses FastMCP's ToolResult class which handles the content_and_artifact
+    format properly. When structured_content is set, to_mcp_result() returns
+    a tuple (content, structured_content).
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        mcp.types.CallToolResult with content and structuredContent
+        FastMCP ToolResult that will be converted to proper MCP format
     """
+    from fastmcp.tools.base import ToolResult
     from mcp import types
 
     file_id = file_info["file_id"]
@@ -225,8 +227,8 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
 
     text = text_message or f"File '{filename}' created successfully."
 
-    # Build file artifact for structuredContent
-    file_artifact = {
+    # Build artifacts dict for structured_content
+    artifacts = {
         "files": [{
             "file_id": file_id,
             "filename": filename,
@@ -234,13 +236,13 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
             "mimeType": mime_type,
             "bytes": file_bytes,
             "source": source,
-        }]
+        }],
+        "file_ids": [file_id]
     }
 
-    # Return CallToolResult directly to bypass FastMCP processing
-    return types.CallToolResult(
-        content=[
-            types.TextContent(type="text", text=text)
-        ],
-        structuredContent=file_artifact,
+    # Return FastMCP ToolResult with structured_content
+    # When structured_content is set, to_mcp_result() returns tuple format
+    return ToolResult(
+        content=[types.TextContent(type="text", text=text)],
+        structured_content=artifacts,
     )

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -201,43 +201,50 @@ async def upload_to_librechat(
     }
 
 
-def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> str:
-    """Format file info as an MCP tool response string.
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
+    """Format file info as an MCP tool response with file artifact.
 
-    Returns a simple string response containing the file details and download URL.
-    FastMCP 3.x handles string returns as TextContent automatically.
+    Returns a ToolResult with structured_content containing the file artifact.
+    LibreChat frontend expects this format for rendering file attachments.
 
-    For LibreChat integration, the response includes:
-    - Success message
-    - File metadata (file_id, filename, size)
-    - Download URL for the LLM to format as a clickable link
+    The structured_content contains:
+    {
+        "content": [
+            {"type": "text", "text": "Success message"},
+            {"type": "file", "file_id": "...", "filename": "...", "mimeType": "..."}
+        ]
+    }
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        Formatted string with file information and download URL
+        ToolResult with structured content for LibreChat
     """
-    download_url = file_info.get("download_url", "")
-    filename = file_info.get("filename", "document")
-    file_id = file_info.get("file_id", "")
-    file_size = file_info.get("bytes", 0)
-    mime_type = file_info.get("type", "application/octet-stream")
+    from fastmcp.server.server import ToolResult
+    from mcp import types
 
-    # Build response parts
-    parts = []
-    
+    content_items = []
+
+    # Add text content if provided
     if text_message:
-        parts.append(text_message)
-    
-    parts.append(f"\n**File Details:**")
-    parts.append(f"- Filename: {filename}")
-    parts.append(f"- Size: {file_size:,} bytes")
-    parts.append(f"- Type: {mime_type}")
-    parts.append(f"- File ID: {file_id}")
-    
-    if download_url:
-        parts.append(f"\n**Download Link:** [{filename}]({download_url})")
-    
-    return "\n".join(parts)
+        content_items.append({
+            "type": "text",
+            "text": text_message,
+        })
+
+    # Add file artifact - this format is expected by LibreChat frontend
+    content_items.append({
+        "type": "file",
+        "file_id": file_info["file_id"],
+        "filename": file_info["filename"],
+        "mimeType": file_info.get("type", "application/octet-stream"),
+    })
+
+    # Return as ToolResult with structured_content
+    # This bypasses FastMCP's content_and_artifact detection
+    return ToolResult(
+        content=[types.TextContent(type="text", text=text_message or "File created.")],
+        structured_content={"content": content_items},
+    )

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -78,7 +78,8 @@ async def upload_to_librechat(
             "filepath": "/path/to/file",
             "type": "application/vnd.openxmlformats-...",
             "bytes": 12345,
-            "source": "local"
+            "source": "local",
+            "download_url": "/api/files/download/{user_id}/{file_id}"
         }
 
     Raises:
@@ -184,48 +185,59 @@ async def upload_to_librechat(
         file_info.get("filename", filename),
     )
 
+    # Construct download URL for LLM to use in responses
+    file_id = file_info["file_id"]
+    download_url = f"/api/files/download/{user_id}/{file_id}"
+
     # Return normalized file metadata
     return {
-        "file_id": file_info["file_id"],
+        "file_id": file_id,
         "filename": file_info.get("filename", filename),
         "filepath": file_info.get("filepath"),
         "type": file_info.get("type", mime_type),
         "bytes": file_info.get("bytes", file_size),
         "source": file_info.get("source", "local"),
+        "download_url": download_url,
     }
 
 
-def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> dict:
-    """Format file info as an MCP tool response with file artifact.
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> str:
+    """Format file info as an MCP tool response string.
 
-    This creates the response structure expected by LibreChat for displaying
-    files as attachments in the chat UI.
+    Returns a simple string response containing the file details and download URL.
+    FastMCP 3.x handles string returns as TextContent automatically.
+
+    For LibreChat integration, the response includes:
+    - Success message
+    - File metadata (file_id, filename, size)
+    - Download URL for the LLM to format as a clickable link
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        MCP tool response dict with content array containing text and file items
+        Formatted string with file information and download URL
     """
-    content = []
+    download_url = file_info.get("download_url", "")
+    filename = file_info.get("filename", "document")
+    file_id = file_info.get("file_id", "")
+    file_size = file_info.get("bytes", 0)
+    mime_type = file_info.get("type", "application/octet-stream")
 
-    # Add text content if provided
+    # Build response parts
+    parts = []
+    
     if text_message:
-        content.append({
-            "type": "text",
-            "text": text_message,
-        })
-
-    # Add file artifact
-    content.append({
-        "type": "file",
-        "file_id": file_info["file_id"],
-        "filename": file_info["filename"],
-        "filepath": file_info.get("filepath"),
-        "mimeType": file_info.get("type"),  # Note: MCP uses mimeType, not type
-        "bytes": file_info.get("bytes"),
-        "source": file_info.get("source", "local"),
-    })
-
-    return {"content": content}
+        parts.append(text_message)
+    
+    parts.append(f"\n**File Details:**")
+    parts.append(f"- Filename: {filename}")
+    parts.append(f"- Size: {file_size:,} bytes")
+    parts.append(f"- Type: {mime_type}")
+    parts.append(f"- File ID: {file_id}")
+    
+    if download_url:
+        parts.append(f"\n**Download Link:** [{filename}]({download_url})")
+    
+    return "\n".join(parts)

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -201,26 +201,21 @@ async def upload_to_librechat(
     }
 
 
-def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> tuple:
-    """Format file info as an MCP tool response with file artifact.
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
+    """Format file info as an MCP CallToolResult with file artifact.
 
-    Returns a two-tuple (text_string, artifacts) for content_and_artifact format.
-    LibreChat/LangChain expects this exact format:
-
-    (
-        "Success message text",  # First element: plain string
-        {                        # Second element: artifacts object
-            "files": [{file info}]
-        }
-    )
+    Returns a CallToolResult directly to bypass FastMCP's response processing.
+    LibreChat will receive the proper MCP format with content and structuredContent.
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        Two-tuple (text_string, artifacts_dict) for content_and_artifact format
+        mcp.types.CallToolResult with content and structuredContent
     """
+    from mcp import types
+
     file_id = file_info["file_id"]
     filename = file_info["filename"]
     filepath = file_info.get("filepath", f"/uploads/{file_id}")
@@ -228,11 +223,10 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None) ->
     file_bytes = file_info.get("bytes", 0)
     source = file_info.get("source", "local")
 
-    # First element: plain text string (not a list of content items)
     text = text_message or f"File '{filename}' created successfully."
 
-    # Second element: artifacts object with files array
-    artifacts = {
+    # Build file artifact for structuredContent
+    file_artifact = {
         "files": [{
             "file_id": file_id,
             "filename": filename,
@@ -243,5 +237,10 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None) ->
         }]
     }
 
-    # Return two-tuple for content_and_artifact format
-    return (text, artifacts)
+    # Return CallToolResult directly to bypass FastMCP processing
+    return types.CallToolResult(
+        content=[
+            types.TextContent(type="text", text=text)
+        ],
+        structuredContent=file_artifact,
+    )

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -204,18 +204,13 @@ async def upload_to_librechat(
 def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> tuple:
     """Format file info as an MCP tool response with file artifact.
 
-    Returns a two-tuple [content, artifacts] for content_and_artifact format.
-    LangChain/LibreChat expects this exact format for file attachments.
+    Returns a two-tuple (text_string, artifacts) for content_and_artifact format.
+    LibreChat/LangChain expects this exact format:
 
-    Format:
     (
-        [  # content list
-            {"type": "text", "text": "Success message"},
-            {"type": "file", "file_id": "...", "filename": "...", "mimeType": "...", ...}
-        ],
-        {  # artifacts object
-            "files": [{file info}],
-            "file_ids": ["file_id"]
+        "Success message text",  # First element: plain string
+        {                        # Second element: artifacts object
+            "files": [{file info}]
         }
     )
 
@@ -224,7 +219,7 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None) ->
         text_message: Optional text message to include with the file
 
     Returns:
-        Two-tuple (content_list, artifacts_dict) for content_and_artifact format
+        Two-tuple (text_string, artifacts_dict) for content_and_artifact format
     """
     file_id = file_info["file_id"]
     filename = file_info["filename"]
@@ -233,29 +228,10 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None) ->
     file_bytes = file_info.get("bytes", 0)
     source = file_info.get("source", "local")
 
-    # Build content list
-    content = []
+    # First element: plain text string (not a list of content items)
+    text = text_message or f"File '{filename}' created successfully."
 
-    # Add text content if provided
-    if text_message:
-        content.append({
-            "type": "text",
-            "text": text_message,
-        })
-
-    # Add file content item
-    file_content_item = {
-        "type": "file",
-        "file_id": file_id,
-        "filename": filename,
-        "filepath": filepath,
-        "mimeType": mime_type,
-        "bytes": file_bytes,
-        "source": source,
-    }
-    content.append(file_content_item)
-
-    # Build artifacts object
+    # Second element: artifacts object with files array
     artifacts = {
         "files": [{
             "file_id": file_id,
@@ -264,9 +240,8 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None) ->
             "mimeType": mime_type,
             "bytes": file_bytes,
             "source": source,
-        }],
-        "file_ids": [file_id],
+        }]
     }
 
     # Return two-tuple for content_and_artifact format
-    return (content, artifacts)
+    return (text, artifacts)

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -201,23 +201,20 @@ async def upload_to_librechat(
     }
 
 
-def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
-    """Format file info using FastMCP ToolResult with structured_content.
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> dict:
+    """Format file info as a simple dict that FastMCP will pass through correctly.
 
-    Uses FastMCP's ToolResult class which handles the content_and_artifact
-    format properly. When structured_content is set, to_mcp_result() returns
-    a tuple (content, structured_content).
+    Returns a dict with 'result' property containing file info. This format
+    is compatible with FastMCP's output schema validation and LibreChat's
+    MCP client expectations.
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        FastMCP ToolResult that will be converted to proper MCP format
+        Dict with result containing message and file info
     """
-    from fastmcp.tools.base import ToolResult
-    from mcp import types
-
     file_id = file_info["file_id"]
     filename = file_info["filename"]
     filepath = file_info.get("filepath", f"/uploads/{file_id}")
@@ -227,22 +224,17 @@ def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
 
     text = text_message or f"File '{filename}' created successfully."
 
-    # Build artifacts dict for structured_content
-    artifacts = {
-        "files": [{
-            "file_id": file_id,
-            "filename": filename,
-            "filepath": filepath,
-            "mimeType": mime_type,
-            "bytes": file_bytes,
-            "source": source,
-        }],
-        "file_ids": [file_id]
+    # Return dict with 'result' property for schema validation
+    return {
+        "result": {
+            "message": text,
+            "file": {
+                "file_id": file_id,
+                "filename": filename,
+                "filepath": filepath,
+                "mimeType": mime_type,
+                "bytes": file_bytes,
+                "source": source,
+            }
+        }
     }
-
-    # Return FastMCP ToolResult with structured_content
-    # When structured_content is set, to_mcp_result() returns tuple format
-    return ToolResult(
-        content=[types.TextContent(type="text", text=text)],
-        structured_content=artifacts,
-    )

--- a/upload_tools/backends/librechat.py
+++ b/upload_tools/backends/librechat.py
@@ -201,50 +201,72 @@ async def upload_to_librechat(
     }
 
 
-def format_file_artifact(file_info: dict, text_message: Optional[str] = None):
+def format_file_artifact(file_info: dict, text_message: Optional[str] = None) -> tuple:
     """Format file info as an MCP tool response with file artifact.
 
-    Returns a ToolResult with structured_content containing the file artifact.
-    LibreChat frontend expects this format for rendering file attachments.
+    Returns a two-tuple [content, artifacts] for content_and_artifact format.
+    LangChain/LibreChat expects this exact format for file attachments.
 
-    The structured_content contains:
-    {
-        "content": [
+    Format:
+    (
+        [  # content list
             {"type": "text", "text": "Success message"},
-            {"type": "file", "file_id": "...", "filename": "...", "mimeType": "..."}
-        ]
-    }
+            {"type": "file", "file_id": "...", "filename": "...", "mimeType": "...", ...}
+        ],
+        {  # artifacts object
+            "files": [{file info}],
+            "file_ids": ["file_id"]
+        }
+    )
 
     Args:
         file_info: Dict returned by upload_to_librechat()
         text_message: Optional text message to include with the file
 
     Returns:
-        ToolResult with structured content for LibreChat
+        Two-tuple (content_list, artifacts_dict) for content_and_artifact format
     """
-    from fastmcp.server.server import ToolResult
-    from mcp import types
+    file_id = file_info["file_id"]
+    filename = file_info["filename"]
+    filepath = file_info.get("filepath", f"/uploads/{file_id}")
+    mime_type = file_info.get("type", "application/octet-stream")
+    file_bytes = file_info.get("bytes", 0)
+    source = file_info.get("source", "local")
 
-    content_items = []
+    # Build content list
+    content = []
 
     # Add text content if provided
     if text_message:
-        content_items.append({
+        content.append({
             "type": "text",
             "text": text_message,
         })
 
-    # Add file artifact - this format is expected by LibreChat frontend
-    content_items.append({
+    # Add file content item
+    file_content_item = {
         "type": "file",
-        "file_id": file_info["file_id"],
-        "filename": file_info["filename"],
-        "mimeType": file_info.get("type", "application/octet-stream"),
-    })
+        "file_id": file_id,
+        "filename": filename,
+        "filepath": filepath,
+        "mimeType": mime_type,
+        "bytes": file_bytes,
+        "source": source,
+    }
+    content.append(file_content_item)
 
-    # Return as ToolResult with structured_content
-    # This bypasses FastMCP's content_and_artifact detection
-    return ToolResult(
-        content=[types.TextContent(type="text", text=text_message or "File created.")],
-        structured_content={"content": content_items},
-    )
+    # Build artifacts object
+    artifacts = {
+        "files": [{
+            "file_id": file_id,
+            "filename": filename,
+            "filepath": filepath,
+            "mimeType": mime_type,
+            "bytes": file_bytes,
+            "source": source,
+        }],
+        "file_ids": [file_id],
+    }
+
+    # Return two-tuple for content_and_artifact format
+    return (content, artifacts)

--- a/upload_tools/main.py
+++ b/upload_tools/main.py
@@ -1,5 +1,16 @@
+"""Unified file upload module supporting multiple storage backends.
+
+This module provides a centralized upload interface that dispatches to the
+configured storage backend (LOCAL, S3, GCS, AZURE, MINIO, or LIBRECHAT).
+
+For LIBRECHAT strategy, uploads go to LibreChat's service endpoint and return
+file metadata for MCP file artifacts instead of URLs.
+"""
+
 import logging
-from config import get_config
+from typing import Union
+
+from config import get_config, StorageStrategy
 from .utils import generate_unique_object_name, generate_named_object_name
 from .backends.local import upload_to_local_folder
 from .backends.s3 import upload_to_s3
@@ -17,29 +28,48 @@ UPLOAD_STRATEGY = cfg.storage.strategy
 SIGNED_URL_EXPIRES_IN = cfg.storage.signed_url_expires_in
 
 # Strategy announcement logs
-if UPLOAD_STRATEGY == "LOCAL":
+if UPLOAD_STRATEGY == StorageStrategy.LOCAL:
     logger.info("Local upload strategy set.")
-elif UPLOAD_STRATEGY == "S3":
+elif UPLOAD_STRATEGY == StorageStrategy.S3:
     logger.info("S3 upload strategy set.")
-elif UPLOAD_STRATEGY == "GCS":
+elif UPLOAD_STRATEGY == StorageStrategy.GCS:
     logger.info("GCS upload strategy set.")
-elif UPLOAD_STRATEGY == "AZURE":
+elif UPLOAD_STRATEGY == StorageStrategy.AZURE:
     logger.info("Azure Blob upload strategy set.")
-elif UPLOAD_STRATEGY == "MINIO":
+elif UPLOAD_STRATEGY == StorageStrategy.MINIO:
     logger.info("MinIO upload strategy set.")
+elif UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT:
+    logger.info("LibreChat upload strategy set.")
 
 
-def upload_file(file_object, suffix: str, filename: str | None = None) -> str:
+def upload_file(
+    file_object,
+    suffix: str,
+    filename: str | None = None,
+    user_context: dict | None = None,
+) -> Union[str, dict]:
     """Upload a file to configured backend and return appropriate response.
+
+    For traditional backends (LOCAL, S3, GCS, AZURE, MINIO), returns a URL string.
+    For LIBRECHAT, this function raises an error - use upload_file_async instead.
 
     :param file_object: File-like object to upload
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
     :param filename: Optional human-readable filename (without extension). When provided,
         the uploaded object will use this name (sanitized) with a short UUID prefix instead
         of a full UUID.
-    :return: Status message with download URL or save location
-    :raises RuntimeError: If upload fails for any reason
+    :param user_context: Optional dict with user info for LIBRECHAT strategy:
+        - user_id: Required for LIBRECHAT
+        - user_email: Optional
+        - conversation_id: Optional
+    :return: Status message with download URL or save location (str for traditional backends)
+    :raises RuntimeError: If upload fails or LIBRECHAT strategy used without async
     """
+    # LIBRECHAT requires async - direct callers to upload_file_async
+    if UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT:
+        raise RuntimeError(
+            "LIBRECHAT strategy requires async upload. Use upload_file_async() instead."
+        )
 
     try:
         if filename:
@@ -51,15 +81,15 @@ def upload_file(file_object, suffix: str, filename: str | None = None) -> str:
         raise RuntimeError(f"Error preparing upload: {e}") from e
 
     try:
-        if UPLOAD_STRATEGY == "LOCAL":
+        if UPLOAD_STRATEGY == StorageStrategy.LOCAL:
             result = upload_to_local_folder(file_object, object_name)
-        elif UPLOAD_STRATEGY == "S3":
+        elif UPLOAD_STRATEGY == StorageStrategy.S3:
             result = upload_to_s3(file_object, object_name, cfg.storage.s3, SIGNED_URL_EXPIRES_IN)
-        elif UPLOAD_STRATEGY == "GCS":
+        elif UPLOAD_STRATEGY == StorageStrategy.GCS:
             result = upload_to_gcs(file_object, object_name, cfg.storage.gcs, SIGNED_URL_EXPIRES_IN)
-        elif UPLOAD_STRATEGY == "AZURE":
+        elif UPLOAD_STRATEGY == StorageStrategy.AZURE:
             result = upload_to_azure(file_object, object_name, cfg.storage.azure, SIGNED_URL_EXPIRES_IN)
-        elif UPLOAD_STRATEGY == "MINIO":
+        elif UPLOAD_STRATEGY == StorageStrategy.MINIO:
             result = upload_to_minio(file_object, object_name, cfg.storage.minio, SIGNED_URL_EXPIRES_IN)
         else:
             logger.error("No upload strategy configured (UPLOAD_STRATEGY='%s')", UPLOAD_STRATEGY)
@@ -75,3 +105,99 @@ def upload_file(file_object, suffix: str, filename: str | None = None) -> str:
         raise RuntimeError(f"Upload to {UPLOAD_STRATEGY} failed. Check server logs for details.")
 
     return result
+
+
+async def upload_file_async(
+    file_object,
+    suffix: str,
+    filename: str | None = None,
+    user_context: dict | None = None,
+) -> Union[str, dict]:
+    """Async upload a file to configured backend.
+
+    This function supports all backends. For LIBRECHAT, it returns a dict with
+    file metadata for MCP file artifacts. For other backends, it returns a URL string.
+
+    :param file_object: File-like object to upload
+    :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
+    :param filename: Optional human-readable filename (without extension). When provided,
+        the uploaded object will use this name (sanitized) with a short UUID prefix instead
+        of a full UUID.
+    :param user_context: Dict with user info (required for LIBRECHAT):
+        - user_id: Required for LIBRECHAT
+        - user_email: Optional
+        - conversation_id: Optional
+    :return: URL string (traditional backends) or dict with file metadata (LIBRECHAT)
+    :raises RuntimeError: If upload fails
+    :raises ValueError: If LIBRECHAT used without user_context
+    """
+    # Generate object name
+    try:
+        if filename:
+            object_name = generate_named_object_name(filename, suffix)
+        else:
+            object_name = generate_unique_object_name(suffix)
+    except Exception as e:
+        logger.error("Failed to generate object name for suffix '%s': %s", suffix, e, exc_info=True)
+        raise RuntimeError(f"Error preparing upload: {e}") from e
+
+    # Handle LIBRECHAT strategy (async)
+    if UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT:
+        from .backends.librechat import upload_to_librechat
+
+        if not user_context:
+            raise ValueError(
+                "LIBRECHAT strategy requires user_context with user_id. "
+                "Ensure X-User-Id header is passed from LibreChat."
+            )
+
+        try:
+            result = await upload_to_librechat(
+                file_object,
+                object_name,
+                user_context,
+                cfg.storage.librechat,
+            )
+            return result
+        except (ValueError, RuntimeError):
+            raise
+        except Exception as e:
+            logger.error("LibreChat upload failed: %s", e, exc_info=True)
+            raise RuntimeError(f"Error uploading to LibreChat: {e}") from e
+
+    # For non-LIBRECHAT strategies, use sync upload
+    # (They don't need user_context and are not truly async)
+    try:
+        if UPLOAD_STRATEGY == StorageStrategy.LOCAL:
+            result = upload_to_local_folder(file_object, object_name)
+        elif UPLOAD_STRATEGY == StorageStrategy.S3:
+            result = upload_to_s3(file_object, object_name, cfg.storage.s3, SIGNED_URL_EXPIRES_IN)
+        elif UPLOAD_STRATEGY == StorageStrategy.GCS:
+            result = upload_to_gcs(file_object, object_name, cfg.storage.gcs, SIGNED_URL_EXPIRES_IN)
+        elif UPLOAD_STRATEGY == StorageStrategy.AZURE:
+            result = upload_to_azure(file_object, object_name, cfg.storage.azure, SIGNED_URL_EXPIRES_IN)
+        elif UPLOAD_STRATEGY == StorageStrategy.MINIO:
+            result = upload_to_minio(file_object, object_name, cfg.storage.minio, SIGNED_URL_EXPIRES_IN)
+        else:
+            logger.error("No upload strategy configured (UPLOAD_STRATEGY='%s')", UPLOAD_STRATEGY)
+            raise RuntimeError("No upload strategy set, document cannot be created.")
+    except RuntimeError:
+        raise
+    except Exception as e:
+        logger.error("Upload failed (strategy=%s): %s", UPLOAD_STRATEGY, e, exc_info=True)
+        raise RuntimeError(f"Error uploading document: {e}") from e
+
+    if result is None:
+        logger.error("Upload backend '%s' returned None for %s – check backend logs for details", UPLOAD_STRATEGY, object_name)
+        raise RuntimeError(f"Upload to {UPLOAD_STRATEGY} failed. Check server logs for details.")
+
+    return result
+
+
+def is_librechat_strategy() -> bool:
+    """Check if current upload strategy is LIBRECHAT.
+
+    Useful for callers to determine if they need to handle file artifacts
+    differently in their response format.
+    """
+    return UPLOAD_STRATEGY == StorageStrategy.LIBRECHAT

--- a/upload_tools/main.py
+++ b/upload_tools/main.py
@@ -47,6 +47,7 @@ def upload_file(
     suffix: str,
     filename: str | None = None,
     user_context: dict | None = None,
+    add_unique_prefix: bool = False,
 ) -> Union[str, dict]:
     """Upload a file to configured backend and return appropriate response.
 
@@ -56,12 +57,13 @@ def upload_file(
     :param file_object: File-like object to upload
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
     :param filename: Optional human-readable filename (without extension). When provided,
-        the uploaded object will use this name (sanitized) with a short UUID prefix instead
-        of a full UUID.
+        the uploaded object will use this name (sanitized).
     :param user_context: Optional dict with user info for LIBRECHAT strategy:
         - user_id: Required for LIBRECHAT
         - user_email: Optional
         - conversation_id: Optional
+    :param add_unique_prefix: If True, adds 8-char UUID prefix to filename for uniqueness.
+        Default False - LibreChat handles uniqueness with its own UUID prefix.
     :return: Status message with download URL or save location (str for traditional backends)
     :raises RuntimeError: If upload fails or LIBRECHAT strategy used without async
     """
@@ -73,7 +75,7 @@ def upload_file(
 
     try:
         if filename:
-            object_name = generate_named_object_name(filename, suffix)
+            object_name = generate_named_object_name(filename, suffix, add_unique_prefix)
         else:
             object_name = generate_unique_object_name(suffix)
     except Exception as e:
@@ -112,6 +114,7 @@ async def upload_file_async(
     suffix: str,
     filename: str | None = None,
     user_context: dict | None = None,
+    add_unique_prefix: bool = False,
 ) -> Union[str, dict]:
     """Async upload a file to configured backend.
 
@@ -121,12 +124,13 @@ async def upload_file_async(
     :param file_object: File-like object to upload
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
     :param filename: Optional human-readable filename (without extension). When provided,
-        the uploaded object will use this name (sanitized) with a short UUID prefix instead
-        of a full UUID.
+        the uploaded object will use this name (sanitized).
     :param user_context: Dict with user info (required for LIBRECHAT):
         - user_id: Required for LIBRECHAT
         - user_email: Optional
         - conversation_id: Optional
+    :param add_unique_prefix: If True, adds 8-char UUID prefix to filename for uniqueness.
+        Default False - LibreChat handles uniqueness with its own UUID prefix.
     :return: URL string (traditional backends) or dict with file metadata (LIBRECHAT)
     :raises RuntimeError: If upload fails
     :raises ValueError: If LIBRECHAT used without user_context
@@ -134,7 +138,7 @@ async def upload_file_async(
     # Generate object name
     try:
         if filename:
-            object_name = generate_named_object_name(filename, suffix)
+            object_name = generate_named_object_name(filename, suffix, add_unique_prefix)
         else:
             object_name = generate_unique_object_name(suffix)
     except Exception as e:

--- a/upload_tools/utils.py
+++ b/upload_tools/utils.py
@@ -26,16 +26,24 @@ def sanitize_filename(name: str) -> str:
     return name or "document"
 
 
-def generate_named_object_name(filename: str, suffix: str) -> str:
-    """Generate an object name using a human-readable filename with a short UUID prefix.
-
+def generate_named_object_name(
+    filename: str, 
+    suffix: str, 
+    add_unique_prefix: bool = False
+) -> str:
+    """Generate an object name using a human-readable filename.
+    
     :param filename: Human-readable filename (will be sanitized)
     :param suffix: File extension (e.g., 'pptx', 'docx', 'xlsx', 'eml')
-    :return: Object name like 'a1b2c3d4_My_Report.docx'
+    :param add_unique_prefix: If True, adds 8-char UUID prefix for uniqueness.
+        Default False - LibreChat handles uniqueness with its own UUID prefix.
+    :return: Object name like 'My_Report.docx' or 'a1b2c3d4_My_Report.docx'
     """
     safe_name = sanitize_filename(filename)
-    short_id = uuid.uuid4().hex[:8]
-    return f"{short_id}_{safe_name}.{suffix}"
+    if add_unique_prefix:
+        short_id = uuid.uuid4().hex[:8]
+        return f"{short_id}_{safe_name}.{suffix}"
+    return f"{safe_name}.{suffix}"
 
 
 def get_content_type(file_name: str) -> str:

--- a/xlsx_tools/__init__.py
+++ b/xlsx_tools/__init__.py
@@ -1,3 +1,3 @@
-from xlsx_tools.base_xlsx_tool import markdown_to_excel
+from xlsx_tools.base_xlsx_tool import markdown_to_excel, _markdown_to_excel_buffer
 
-__all__ = ["markdown_to_excel"]
+__all__ = ["markdown_to_excel", "_markdown_to_excel_buffer"]

--- a/xlsx_tools/base_xlsx_tool.py
+++ b/xlsx_tools/base_xlsx_tool.py
@@ -146,3 +146,94 @@ def markdown_to_excel(markdown_content: str, file_name: str | None = None, auto_
         raise RuntimeError(f"Error saving/uploading Excel workbook: {e}") from e
     finally:
         file_object.close()
+
+
+def _markdown_to_excel_buffer(markdown_content: str, auto_filter: bool = False) -> io.BytesIO:
+    """Convert Markdown to Excel workbook and return as BytesIO buffer.
+
+    This function is useful when the caller needs to handle upload separately,
+    such as for LibreChat file artifact uploads.
+
+    Args:
+        markdown_content: Markdown string with tables.
+        auto_filter: If True, apply Excel auto-filter to each table.
+
+    Returns:
+        BytesIO buffer containing the Excel workbook (position at start)
+
+    Raises:
+        RuntimeError: If the markdown contains no tables or conversion fails.
+    """
+    logger.info("Starting _markdown_to_excel_buffer conversion")
+
+    # ── Input validation ──
+    if not markdown_content or not markdown_content.strip():
+        raise RuntimeError("Cannot create Excel workbook: markdown content is empty")
+
+    # Split content into lines and parse into events (single shared state machine)
+    lines: list[str] = markdown_content.split('\n')
+    events = walk_markdown_lines(lines)
+
+    # Build table position map from events (used for cross-sheet formula resolution)
+    all_sheet_table_positions = collect_table_positions(events)
+
+    # ── Build the actual workbook from events ──
+    wb = Workbook()
+    ws = wb.active
+    ws.title = _sanitize_sheet_name(DEFAULT_SHEET_NAME)
+
+    # Per-sheet state for formula resolution
+    table_positions: dict[str, int] = {}
+
+    # Counters for summary
+    tables_count = 0
+
+    try:
+        for event in events:
+            if isinstance(event, SheetEvent):
+                if event.is_rename:
+                    try:
+                        ws.title = event.sheet_name
+                    except (SheetTitleException, ValueError):
+                        pass
+                else:
+                    try:
+                        ws = wb.create_sheet(title=event.sheet_name)
+                    except (SheetTitleException, ValueError):
+                        ws = wb.create_sheet()
+                    table_positions = {}
+
+            elif isinstance(event, HeaderEvent):
+                cell = ws.cell(row=event.row, column=1)
+                cell.value = event.text
+                cell.font = HEADER_FONTS.get(event.level, HEADER_FONT_DEFAULT)
+
+            elif isinstance(event, TableEvent):
+                table_positions[event.table_key] = event.start_row
+                add_table_to_sheet(
+                    event.table_data, ws, event.start_row, table_positions,
+                    all_sheet_table_positions=all_sheet_table_positions,
+                    auto_filter=auto_filter,
+                    table_index=tables_count,
+                    directives=event.directives,
+                )
+                if 'freeze' in event.directives:
+                    ws.freeze_panes = f"A{event.start_row + 1}"
+                tables_count += 1
+
+    except Exception as e:
+        raise RuntimeError(f"Error generating Excel workbook: {e}") from e
+
+    if tables_count == 0:
+        raise RuntimeError(
+            "Cannot create Excel workbook: no valid markdown tables found in the input."
+        )
+
+    # Save workbook to BytesIO
+    file_object = io.BytesIO()
+    try:
+        wb.save(file_object)
+        file_object.seek(0)
+        return file_object
+    except Exception as e:
+        raise RuntimeError(f"Error saving Excel workbook: {e}") from e

--- a/xml_tools/__init__.py
+++ b/xml_tools/__init__.py
@@ -1,4 +1,3 @@
-from .base_xml_tool import create_xml_file, XMLValidationError, XMLFileCreationError
+from .base_xml_tool import create_xml_file, _create_xml_buffer, XMLValidationError, XMLFileCreationError
 
-__all__ = ["create_xml_file", "XMLValidationError", "XMLFileCreationError"]
-
+__all__ = ["create_xml_file", "_create_xml_buffer", "XMLValidationError", "XMLFileCreationError"]

--- a/xml_tools/base_xml_tool.py
+++ b/xml_tools/base_xml_tool.py
@@ -54,22 +54,25 @@ def validate_xml(xml_content: str) -> Tuple[bool, str]:
         return False, f"Unexpected error during XML validation: {str(e)}"
 
 
-def create_xml_file(xml_content: str, file_name: str | None = None) -> str:
-    """Create an XML file from the provided XML content.
+def _create_xml_buffer(xml_content: str) -> io.BytesIO:
+    """Create an XML file buffer from the provided XML content.
 
-    Validates that the content is well-formed XML before saving.
+    This function is useful when the caller needs to handle upload separately,
+    such as for LibreChat file artifact uploads.
+
+    Validates that the content is well-formed XML before creating the buffer.
 
     Args:
         xml_content: Complete, valid XML content string.
 
     Returns:
-        A status message with the download URL or file path.
+        BytesIO buffer containing the XML file (position at start)
 
     Raises:
         XMLValidationError: If the XML content is invalid or contains security threats.
-        XMLFileCreationError: If file creation or upload fails.
+        XMLFileCreationError: If buffer creation fails.
     """
-    logger.info("Starting XML file creation")
+    logger.info("Starting XML buffer creation")
 
     # Strip leading/trailing whitespace
     xml_content = xml_content.strip()
@@ -88,29 +91,46 @@ def create_xml_file(xml_content: str, file_name: str | None = None) -> str:
         match = re.search(r'encoding=["\']([^"\']+)["\']', xml_content)
         if match:
             encoding = match.group(1)
-            logger.debug(f"Using encoding from XML declaration: {encoding}")
     else:
         # Add UTF-8 declaration if no declaration present
         xml_content = '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_content
-        logger.debug("Added XML declaration with UTF-8 encoding")
 
     try:
-        # Create a file-like object from the XML content using declared encoding
         xml_bytes = xml_content.encode(encoding)
         file_object = io.BytesIO(xml_bytes)
+        return file_object
+    except Exception as e:
+        logger.error(f"Error creating XML buffer: {str(e)}", exc_info=True)
+        raise XMLFileCreationError(f"Error creating XML buffer: {str(e)}") from e
 
-        try:
-            # Upload the file
-            result = upload_file(file_object, "xml", filename=file_name)
-            logger.info("XML file uploaded successfully")
-            return result
-        finally:
-            file_object.close()
 
+def create_xml_file(xml_content: str, file_name: str | None = None) -> str:
+    """Create an XML file from the provided XML content.
+
+    Validates that the content is well-formed XML before saving.
+
+    Args:
+        xml_content: Complete, valid XML content string.
+
+    Returns:
+        A status message with the download URL or file path.
+
+    Raises:
+        XMLValidationError: If the XML content is invalid or contains security threats.
+        XMLFileCreationError: If file creation or upload fails.
+    """
+    file_object = None
+    try:
+        file_object = _create_xml_buffer(xml_content)
+        result = upload_file(file_object, "xml", filename=file_name)
+        logger.info("XML file uploaded successfully")
+        return result
     except (XMLValidationError, XMLFileCreationError):
-        # Re-raise our custom exceptions as-is
         raise
     except Exception as e:
         logger.error(f"Error creating XML file: {str(e)}", exc_info=True)
         raise XMLFileCreationError(f"Error creating XML file: {str(e)}") from e
+    finally:
+        if file_object:
+            file_object.close()
 


### PR DESCRIPTION
With this change I want to introduce a way to integrate the mcp-ms-office-documents to LibreChat.

When using the new `UPLOAD_STRATEGY=LIBRECHAT`, generated documents (DOCX, XLSX, PPTX, EML, XML) are uploaded directly to LibreChat's internal file service and appear as downloadable attachments in the chat UI — no external cloud storage required.

---

## What's New

### New Upload Strategy: `LIBRECHAT`

A new storage backend that uploads files to LibreChat's `/api/service/files` endpoint instead of S3/GCS/Azure/MinIO.

### User Context from HTTP Headers

LibreChat passes user identity via headers:
- `X-User-Id` (required) — associates files with the user
- `X-User-Email` (optional) — for audit logging  
- `X-Conversation-Id` (optional) — for conversation-scoped access

### Service Token Authentication

Secure server-to-server communication using `X-Service-Token` header. The token must match `MCP_SERVICE_TOKEN` configured in LibreChat's environment.

### Optional UUID Prefix Control

All tools now accept `add_unique_prefix` parameter (default `false`). Since LibreChat adds its own UUID prefix during storage, the MCP server prefix is disabled by default to avoid redundant prefixes.

---

## Configuration

```bash
# .env
UPLOAD_STRATEGY=LIBRECHAT
LIBRECHAT_SERVICE_URL=http://api:3080/api/service/files
LIBRECHAT_SERVICE_TOKEN=<must-match-MCP_SERVICE_TOKEN-in-LibreChat>
```

```yaml
# librechat.yaml
mcpServers:
  Office-documents:
    type: streamable-http
    url: http://mcp-office-docs:8958/mcp
    headers:
      X-User-Id: "{{LIBRECHAT_USER_ID}}"
      X-User-Email: "{{LIBRECHAT_USER_EMAIL}}"
```

---

## New Files

| File | Description |
|------|-------------|
| `librechat_integration.py` | User context extraction and upload helpers |
| `upload_tools/backends/librechat.py` | LibreChat file service upload backend |
| `tests/test_librechat_integration.py` | Unit tests for LibreChat functionality |
| `tests/test_upload_unique_prefix.py` | Tests for UUID prefix control |

---

## Modified Files

| File | Changes |
|------|---------|
| `config.py` | Added `LibreChatSettings` and `LIBRECHAT` strategy |
| `main.py` | Updated tool handlers with LibreChat support |
| `upload_tools/main.py` | Added `upload_file_async()` and `is_librechat_strategy()` |
| `upload_tools/utils.py` | Added `add_unique_prefix` parameter |
| `*_tools/base_*_tool.py` | Added `_*_buffer()` functions for buffer-only generation |
| `.env.example` | Added LibreChat configuration variables |
| `AGENTS.md`, `Readme.md` | Documentation updates |

---

## How It Works

1. LibreChat calls MCP tool with user headers (`X-User-Id`, etc.)
2. MCP server generates document (DOCX/XLSX/PPTX/EML/XML)
3. Document is uploaded to LibreChat via `POST /api/service/files`
4. MCP returns file artifact response with `file_id`, `filename`, `mimeType`
5. File appears as attachment in LibreChat conversation

---

## Testing

```bash
pytest tests/test_librechat_integration.py tests/test_upload_unique_prefix.py -v
```

All tests pass (17 tests in test_librechat_integration + 10 tests in test_upload_unique_prefix).

---

## Backward Compatibility

Existing deployments using `LOCAL`, `S3`, `GCS`, `AZURE`, or `MINIO` strategies continue to work unchanged. The LibreChat integration is fully opt-in.
